### PR TITLE
[FEAT] 피드 7개씩 전송하는 api

### DIFF
--- a/src/main/kotlin/com/example/mykku/board/domain/Board.kt
+++ b/src/main/kotlin/com/example/mykku/board/domain/Board.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class Board(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "title")

--- a/src/main/kotlin/com/example/mykku/board/domain/Board.kt
+++ b/src/main/kotlin/com/example/mykku/board/domain/Board.kt
@@ -3,12 +3,11 @@ package com.example.mykku.board.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.feed.domain.Feed
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class Board(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "title")
     var title: String,

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
@@ -3,12 +3,11 @@ package com.example.mykku.dailymessage.domain
 import com.example.mykku.common.domain.BaseEntity
 import jakarta.persistence.*
 import java.time.LocalDate
-import java.util.*
 
 @Entity
 class DailyMessage(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "content")
     var content: String,

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 @Entity
 class DailyMessage(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "content")

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class DailyMessageComment(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "content")

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
@@ -3,12 +3,11 @@ package com.example.mykku.dailymessage.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class DailyMessageComment(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "content")
     var content: String,

--- a/src/main/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepository.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepository.kt
@@ -6,10 +6,9 @@ import com.example.mykku.exception.MykkuException
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
-import java.util.*
 
 @Repository
-interface DailyMessageRepository : JpaRepository<DailyMessage, UUID> {
+interface DailyMessageRepository : JpaRepository<DailyMessage, Long> {
     fun findByDate(date: LocalDate): DailyMessage?
 
     fun getByDate(date: LocalDate): DailyMessage {

--- a/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
@@ -2,10 +2,10 @@ package com.example.mykku.dailymessage.tool
 
 import com.example.mykku.dailymessage.domain.DailyMessage
 import com.example.mykku.dailymessage.repository.DailyMessageRepository
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Component
 import java.time.LocalDate
 
-@Service
+@Component
 class DailyMessageReader(
     private val dailyMessageRepository: DailyMessageRepository,
 ) {

--- a/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
@@ -1,0 +1,25 @@
+package com.example.mykku.feed.controller
+
+import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.feed.dto.FeedsResponse
+import com.example.mykku.feed.service.FeedService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class FeedController(
+    private val feedService: FeedService,
+) {
+    @GetMapping("/api/{memberId}/feeds")
+    fun getFeeds(@PathVariable memberId: String): ResponseEntity<ApiResponse<FeedsResponse>> {
+        val feeds = feedService.getFeeds(memberId)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "홈 피드 목록 불러오기에 성공했습니다.",
+                data = feeds
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/domain/BasicEvent.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/BasicEvent.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import jakarta.persistence.*
 import java.time.LocalDateTime
-import java.util.*
 
 @Entity
 @Table(name = "basic_events")
@@ -18,7 +17,7 @@ import java.util.*
 )
 abstract class BasicEvent(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "title")
     var title: String,

--- a/src/main/kotlin/com/example/mykku/feed/domain/BasicEvent.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/BasicEvent.kt
@@ -17,6 +17,7 @@ import java.time.LocalDateTime
 )
 abstract class BasicEvent(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "title")

--- a/src/main/kotlin/com/example/mykku/feed/domain/BasicEventImage.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/BasicEventImage.kt
@@ -1,12 +1,11 @@
 package com.example.mykku.feed.domain
 
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class BasicEventImage(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "url")
     var url: String,

--- a/src/main/kotlin/com/example/mykku/feed/domain/BasicEventImage.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/BasicEventImage.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.*
 @Entity
 class BasicEventImage(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "url")

--- a/src/main/kotlin/com/example/mykku/feed/domain/ContestWinner.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/ContestWinner.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.*
 @Entity
 class ContestWinner(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "rank")

--- a/src/main/kotlin/com/example/mykku/feed/domain/ContestWinner.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/ContestWinner.kt
@@ -2,12 +2,11 @@ package com.example.mykku.feed.domain
 
 import com.example.mykku.common.domain.BaseEntity
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class ContestWinner(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "rank")
     var rank: Int,

--- a/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.*
 @Entity
 class Feed(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "title")

--- a/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
@@ -4,12 +4,11 @@ import com.example.mykku.board.domain.Board
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class Feed(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "title")
     var title: String,

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class FeedComment(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "content")

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
@@ -3,12 +3,11 @@ package com.example.mykku.feed.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class FeedComment(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "content")
     var content: String,

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
@@ -1,12 +1,11 @@
 package com.example.mykku.feed.domain
 
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class FeedImage(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "url")
     var url: String,

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.*
 @Entity
 class FeedImage(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "url")

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedTag.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedTag.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.*
 @Entity
 class FeedTag(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedTag.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedTag.kt
@@ -2,12 +2,11 @@ package com.example.mykku.feed.domain
 
 import com.example.mykku.common.domain.BaseEntity
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class FeedTag(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")

--- a/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
@@ -17,6 +17,7 @@ import jakarta.persistence.*
 )
 abstract class Tag(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @Column(name = "title")

--- a/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
@@ -4,7 +4,6 @@ import com.example.mykku.common.domain.BaseEntity
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 @Table(name = "tags")
@@ -18,7 +17,7 @@ import java.util.*
 )
 abstract class Tag(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @Column(name = "title")
     var title: String,

--- a/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
@@ -1,0 +1,8 @@
+package com.example.mykku.feed.dto
+
+data class AuthorResponse(
+    val memberId: String,
+    val nickname: String,
+    val profileImageUrl: String,
+    val role: String,
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
@@ -1,8 +1,17 @@
 package com.example.mykku.feed.dto
 
+import com.example.mykku.member.domain.Member
+
 data class AuthorResponse(
     val memberId: String,
     val nickname: String,
-    val profileImageUrl: String,
+    val profileImage: String,
     val role: String,
-)
+) {
+    constructor(member: Member) : this(
+        memberId = member.id,
+        nickname = member.nickname,
+        profileImage = member.profileImage,
+        role = member.role,
+    )
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/CommentPreviewResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CommentPreviewResponse.kt
@@ -1,0 +1,6 @@
+package com.example.mykku.feed.dto
+
+data class CommentPreviewResponse(
+    val profileImage: String,
+    val content: String,
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/CommentPreviewResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CommentPreviewResponse.kt
@@ -1,6 +1,13 @@
 package com.example.mykku.feed.dto
 
+import com.example.mykku.feed.domain.FeedComment
+
 data class CommentPreviewResponse(
     val profileImage: String,
     val content: String,
-)
+) {
+    constructor(comment: FeedComment) : this(
+        profileImage = comment.member.profileImage,
+        content = comment.content
+    )
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/ContestWinnerResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/ContestWinnerResponse.kt
@@ -1,9 +1,15 @@
 package com.example.mykku.feed.dto
 
-import java.util.*
+import com.example.mykku.feed.domain.ContestWinner
 
 data class ContestWinnerResponse(
-    val id: UUID,
+    val id: Long,
     val image: String,
     val rank: Int,
-)
+) {
+    constructor(winner: ContestWinner) : this(
+        id = winner.id!!,
+        image = winner.image,
+        rank = winner.rank
+    )
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/ContestWinnersResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/ContestWinnersResponse.kt
@@ -9,7 +9,7 @@ data class ContestWinnersResponse(
     constructor(contest: Contest) : this(
         title = contest.title,
         winners = contest.contestWinners
-            .map { winner -> ContestWinnerResponse(winner.id, winner.image, winner.rank) }
+            .map { winner -> ContestWinnerResponse(winner) }
             .sortedBy { it.rank }
     )
 }

--- a/src/main/kotlin/com/example/mykku/feed/dto/EventPreviewResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/EventPreviewResponse.kt
@@ -1,14 +1,13 @@
 package com.example.mykku.feed.dto
 
 import com.example.mykku.feed.domain.BasicEvent
-import java.util.*
 
 data class EventPreviewResponse(
-    val id: UUID,
+    val id: Long,
     val images: List<String>
 ) {
     constructor(event: BasicEvent) : this(
-        id = event.id,
+        id = event.id!!,
         images = event.basicEventImages.map { it.url }
     )
 }

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedPreviewResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedPreviewResponse.kt
@@ -1,17 +1,18 @@
 package com.example.mykku.feed.dto
 
+import com.example.mykku.feed.domain.Feed
 import java.util.*
 
 data class FeedPreviewResponse(
-    val id: UUID,
+    val id: Long,
     val board: String,
     val title: String,
     val content: String,
     val likeCount: Int,
     val commentCount: Int,
 ) {
-    constructor(feed: com.example.mykku.feed.domain.Feed) : this(
-        id = feed.id,
+    constructor(feed: Feed) : this(
+        id = feed.id!!,
         board = feed.board.title,
         title = feed.title,
         content = feed.content,

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.feed.dto
+
+import java.time.LocalDateTime
+
+data class FeedResponse(
+    val id: Long,
+    val author: AuthorResponse,
+    val board: String,
+    val createdAt: LocalDateTime,
+    val title: String,
+    val content: String,
+    val images: List<String>,
+    val tags: List<String>,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    val isSaved: Boolean,
+    val commentCount: Int,
+    val comment: CommentPreviewResponse,
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
@@ -1,5 +1,6 @@
 package com.example.mykku.feed.dto
 
+import com.example.mykku.feed.domain.Feed
 import java.time.LocalDateTime
 
 data class FeedResponse(
@@ -16,4 +17,33 @@ data class FeedResponse(
     val isSaved: Boolean,
     val commentCount: Int,
     val comment: CommentPreviewResponse,
-)
+) {
+    constructor(feed: Feed, author: AuthorResponse, isLiked: Boolean, isSaved: Boolean) : this(
+        id = feed.id!!,
+        author = author,
+        board = feed.board.title,
+        createdAt = feed.createdAt,
+        title = feed.title,
+        content = feed.content,
+        images = feed.feedImages.map { it.url },
+        tags = feed.feedTags.map { it.tag.title },
+        likeCount = feed.likeCount,
+        isLiked = isLiked,
+        isSaved = isSaved,
+        commentCount = feed.commentCount,
+        comment = getFirstComment(feed)
+    )
+
+    companion object {
+        private fun getFirstComment(feed: Feed): CommentPreviewResponse {
+            val feedComments = feed.feedComments
+            if (feedComments.isEmpty()) {
+                return CommentPreviewResponse(
+                    profileImage = "",
+                    content = ""
+                )
+            }
+            return CommentPreviewResponse(feedComments[0])
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedsResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedsResponse.kt
@@ -1,0 +1,5 @@
+package com.example.mykku.feed.dto
+
+data class FeedsResponse(
+    val feeds: List<FeedResponse>,
+)

--- a/src/main/kotlin/com/example/mykku/feed/repository/BasicEventRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/BasicEventRepository.kt
@@ -5,10 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
-import java.util.*
 
 @Repository
-interface BasicEventRepository : JpaRepository<BasicEvent, UUID> {
+interface BasicEventRepository : JpaRepository<BasicEvent, Long> {
     @Query(
         """
             SELECT be

--- a/src/main/kotlin/com/example/mykku/feed/repository/ContestRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/ContestRepository.kt
@@ -3,7 +3,6 @@ package com.example.mykku.feed.repository
 import com.example.mykku.feed.domain.Contest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.util.*
 
 @Repository
-interface ContestRepository : JpaRepository<Contest, UUID>
+interface ContestRepository : JpaRepository<Contest, Long>

--- a/src/main/kotlin/com/example/mykku/feed/repository/FeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/FeedRepository.kt
@@ -1,9 +1,12 @@
 package com.example.mykku.feed.repository
 
 import com.example.mykku.feed.domain.Feed
+import com.example.mykku.member.domain.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
-interface FeedRepository : JpaRepository<Feed, UUID>
+interface FeedRepository : JpaRepository<Feed, UUID> {
+    fun findAllByMemberIn(members: List<Member>): List<Feed>
+}

--- a/src/main/kotlin/com/example/mykku/feed/repository/FeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/FeedRepository.kt
@@ -4,9 +4,8 @@ import com.example.mykku.feed.domain.Feed
 import com.example.mykku.member.domain.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.util.*
 
 @Repository
-interface FeedRepository : JpaRepository<Feed, UUID> {
+interface FeedRepository : JpaRepository<Feed, Long> {
     fun findAllByMemberIn(members: List<Member>): List<Feed>
 }

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -2,7 +2,6 @@ package com.example.mykku.feed.service
 
 import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.dto.AuthorResponse
-import com.example.mykku.feed.dto.CommentPreviewResponse
 import com.example.mykku.feed.dto.FeedResponse
 import com.example.mykku.feed.dto.FeedsResponse
 import com.example.mykku.feed.tool.FeedReader
@@ -31,27 +30,10 @@ class FeedService(
         val isLiked = likeFeedReader.isLiked(feed.member, feed)
         val isSaved = saveFeedReader.isSaved(feed.member, feed)
         return FeedResponse(
-            id = feed.id!!,
+            feed = feed,
             author = authorResponse,
-            board = feed.board.title,
-            createdAt = feed.createdAt,
-            title = feed.title,
-            content = feed.content,
-            images = feed.feedImages.map { it.url },
-            tags = feed.feedTags.map { it.tag.title },
-            likeCount = feed.likeCount,
             isLiked = isLiked,
             isSaved = isSaved,
-            commentCount = feed.commentCount,
-            comment = feed.feedComments.firstOrNull()?.let { comment ->
-                CommentPreviewResponse(
-                    profileImage = comment.member.profileImage,
-                    content = comment.content,
-                )
-            } ?: CommentPreviewResponse(
-                profileImage = "",
-                content = "",
-            )
         )
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -21,14 +21,14 @@ class FeedService(
         val follower = memberReader.getFollowerByMemberId(memberId)
         val feeds = feedReader.getFeedsByFollower(follower)
         return FeedsResponse(
-            feeds = feeds.map { feed -> getFeedResponse(feed) }
+            feeds = feeds.map { feed -> getFeedResponse(memberId, feed) }
         )
     }
 
-    private fun getFeedResponse(feed: Feed): FeedResponse {
+    private fun getFeedResponse(memberId: String, feed: Feed): FeedResponse {
         val authorResponse = AuthorResponse(feed.member)
-        val isLiked = likeFeedReader.isLiked(feed.member, feed)
-        val isSaved = saveFeedReader.isSaved(feed.member, feed)
+        val isLiked = likeFeedReader.isLiked(memberId, feed)
+        val isSaved = saveFeedReader.isSaved(memberId, feed)
         return FeedResponse(
             feed = feed,
             author = authorResponse,

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -1,0 +1,26 @@
+package com.example.mykku.feed.service
+
+import com.example.mykku.feed.domain.Feed
+import com.example.mykku.feed.dto.FeedResponse
+import com.example.mykku.feed.dto.FeedsResponse
+import com.example.mykku.feed.tool.FeedReader
+import com.example.mykku.member.tool.MemberReader
+import org.springframework.stereotype.Service
+
+@Service
+class FeedService(
+    private val feedReader: FeedReader,
+    private val memberReader: MemberReader,
+) {
+    fun getFeeds(memberId: String): FeedsResponse {
+        val follower = memberReader.getFollowerByMemberId(memberId)
+        val feeds = feedReader.getFeedsByFollower(follower)
+        return FeedsResponse(
+            feeds = feeds.map { feed -> getFeedResponse(feed) }
+        )
+    }
+
+    private fun getFeedResponse(feed: Feed): FeedResponse {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -1,16 +1,22 @@
 package com.example.mykku.feed.service
 
 import com.example.mykku.feed.domain.Feed
+import com.example.mykku.feed.dto.AuthorResponse
+import com.example.mykku.feed.dto.CommentPreviewResponse
 import com.example.mykku.feed.dto.FeedResponse
 import com.example.mykku.feed.dto.FeedsResponse
 import com.example.mykku.feed.tool.FeedReader
+import com.example.mykku.member.tool.LikeFeedReader
 import com.example.mykku.member.tool.MemberReader
+import com.example.mykku.member.tool.SaveFeedReader
 import org.springframework.stereotype.Service
 
 @Service
 class FeedService(
     private val feedReader: FeedReader,
     private val memberReader: MemberReader,
+    private val likeFeedReader: LikeFeedReader,
+    private val saveFeedReader: SaveFeedReader
 ) {
     fun getFeeds(memberId: String): FeedsResponse {
         val follower = memberReader.getFollowerByMemberId(memberId)
@@ -21,6 +27,31 @@ class FeedService(
     }
 
     private fun getFeedResponse(feed: Feed): FeedResponse {
-        TODO("Not yet implemented")
+        val authorResponse = AuthorResponse(feed.member)
+        val isLiked = likeFeedReader.isLiked(feed.member, feed)
+        val isSaved = saveFeedReader.isSaved(feed.member, feed)
+        return FeedResponse(
+            id = feed.id!!,
+            author = authorResponse,
+            board = feed.board.title,
+            createdAt = feed.createdAt,
+            title = feed.title,
+            content = feed.content,
+            images = feed.feedImages.map { it.url },
+            tags = feed.feedTags.map { it.tag.title },
+            likeCount = feed.likeCount,
+            isLiked = isLiked,
+            isSaved = isSaved,
+            commentCount = feed.commentCount,
+            comment = feed.feedComments.firstOrNull()?.let { comment ->
+                CommentPreviewResponse(
+                    profileImage = comment.member.profileImage,
+                    content = comment.content,
+                )
+            } ?: CommentPreviewResponse(
+                profileImage = "",
+                content = "",
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/tool/BasicEventReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/BasicEventReader.kt
@@ -2,10 +2,10 @@ package com.example.mykku.feed.tool
 
 import com.example.mykku.feed.dto.EventPreviewResponse
 import com.example.mykku.feed.repository.BasicEventRepository
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
-@Service
+@Component
 class BasicEventReader(
     private val basicEventRepository: BasicEventRepository,
 ) {

--- a/src/main/kotlin/com/example/mykku/feed/tool/ContestReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/ContestReader.kt
@@ -2,9 +2,9 @@ package com.example.mykku.feed.tool
 
 import com.example.mykku.feed.dto.ContestWinnersResponse
 import com.example.mykku.feed.repository.ContestRepository
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Component
 
-@Service
+@Component
 class ContestReader(
     private val contestRepository: ContestRepository
 ) {

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
@@ -1,10 +1,12 @@
 package com.example.mykku.feed.tool
 
+import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.dto.FeedPreviewResponse
 import com.example.mykku.feed.repository.FeedRepository
-import org.springframework.stereotype.Service
+import com.example.mykku.member.domain.Member
+import org.springframework.stereotype.Component
 
-@Service
+@Component
 class FeedReader(
     private val feedRepository: FeedRepository,
 ) {
@@ -13,5 +15,9 @@ class FeedReader(
             .map { feed -> FeedPreviewResponse(feed) }
             .take(5)
         return emptyList()
+    }
+
+    fun getFeedsByFollower(memberId: List<Member>): List<Feed> {
+        return feedRepository.findAllByMemberIn(memberId)
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
@@ -17,7 +17,7 @@ class FeedReader(
         return emptyList()
     }
 
-    fun getFeedsByFollower(memberId: List<Member>): List<Feed> {
-        return feedRepository.findAllByMemberIn(memberId)
+    fun getFeedsByFollower(members: List<Member>): List<Feed> {
+        return feedRepository.findAllByMemberIn(members)
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedReader.kt
@@ -11,10 +11,9 @@ class FeedReader(
     private val feedRepository: FeedRepository,
 ) {
     fun getFeedPreviews(): List<FeedPreviewResponse> {
-        feedRepository.findAll()
+        return feedRepository.findAll()
             .map { feed -> FeedPreviewResponse(feed) }
             .take(5)
-        return emptyList()
     }
 
     fun getFeedsByFollower(members: List<Member>): List<Feed> {

--- a/src/main/kotlin/com/example/mykku/member/domain/Follow.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/Follow.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.member.domain
+
+import jakarta.persistence.*
+
+@Entity
+class Follow(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    val follower: Member,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    val following: Member
+) {
+}

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeDailyMessageComment.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeDailyMessageComment.kt
@@ -3,12 +3,11 @@ package com.example.mykku.member.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.dailymessage.domain.DailyMessageComment
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class LikeDailyMessageComment(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeDailyMessageComment.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeDailyMessageComment.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class LikeDailyMessageComment(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeFeed.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeFeed.kt
@@ -3,12 +3,11 @@ package com.example.mykku.member.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.feed.domain.Feed
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class LikeFeed(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeFeed.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeFeed.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class LikeFeed(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeFeedComment.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeFeedComment.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class LikeFeedComment(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/member/domain/LikeFeedComment.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/LikeFeedComment.kt
@@ -3,12 +3,11 @@ package com.example.mykku.member.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.feed.domain.FeedComment
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class LikeFeedComment(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/kotlin/com/example/mykku/member/domain/Member.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/Member.kt
@@ -11,6 +11,12 @@ class Member(
     @Column(name = "nickname")
     var nickname: String,
 
+    @Column(name = "role")
+    var role: String,
+
+    @Column(name = "profile_image")
+    var profileImage: String,
+
     @Column(name = "follower_count")
     var followerCount: Int = 0,
 

--- a/src/main/kotlin/com/example/mykku/member/domain/SaveDailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/SaveDailyMessage.kt
@@ -3,12 +3,11 @@ package com.example.mykku.member.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.dailymessage.domain.DailyMessage
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class SaveDailyMessage(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/kotlin/com/example/mykku/member/domain/SaveDailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/SaveDailyMessage.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class SaveDailyMessage(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/member/domain/SaveFeed.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/SaveFeed.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.*
 @Entity
 class SaveFeed(
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/example/mykku/member/domain/SaveFeed.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/SaveFeed.kt
@@ -3,12 +3,11 @@ package com.example.mykku.member.domain
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.feed.domain.Feed
 import jakarta.persistence.*
-import java.util.*
 
 @Entity
 class SaveFeed(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/kotlin/com/example/mykku/member/repository/FollowRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/FollowRepository.kt
@@ -1,0 +1,10 @@
+package com.example.mykku.member.repository
+
+import com.example.mykku.member.domain.Follow
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FollowRepository : JpaRepository<Follow, Long> {
+    fun findByFollowerId(followerId: String): List<Follow>
+}

--- a/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
@@ -2,11 +2,10 @@ package com.example.mykku.member.repository
 
 import com.example.mykku.feed.domain.Feed
 import com.example.mykku.member.domain.LikeFeed
-import com.example.mykku.member.domain.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface LikeFeedRepository : JpaRepository<LikeFeed, Long> {
-    fun existsByMemberAndFeed(member: Member, feed: Feed): Boolean
+    fun existsByMemberIdAndFeed(memberId: String, feed: Feed): Boolean
 }

--- a/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
@@ -1,0 +1,8 @@
+package com.example.mykku.member.repository
+
+import com.example.mykku.member.domain.LikeFeed
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface LikeFeedRepository : JpaRepository<LikeFeed, Long>

--- a/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/LikeFeedRepository.kt
@@ -1,8 +1,12 @@
 package com.example.mykku.member.repository
 
+import com.example.mykku.feed.domain.Feed
 import com.example.mykku.member.domain.LikeFeed
+import com.example.mykku.member.domain.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface LikeFeedRepository : JpaRepository<LikeFeed, Long>
+interface LikeFeedRepository : JpaRepository<LikeFeed, Long> {
+    fun existsByMemberAndFeed(member: Member, feed: Feed): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/MemberRepository.kt
@@ -1,0 +1,9 @@
+package com.example.mykku.member.repository
+
+import com.example.mykku.member.domain.Member
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberRepository : JpaRepository<Member, String> {
+}

--- a/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
@@ -1,0 +1,8 @@
+package com.example.mykku.member.repository
+
+import com.example.mykku.member.domain.SaveFeed
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface SaveFeedRepository : JpaRepository<SaveFeed, Long>

--- a/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
@@ -1,8 +1,12 @@
 package com.example.mykku.member.repository
 
+import com.example.mykku.feed.domain.Feed
+import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SaveFeed
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface SaveFeedRepository : JpaRepository<SaveFeed, Long>
+interface SaveFeedRepository : JpaRepository<SaveFeed, Long> {
+    fun existsByMemberAndFeed(member: Member, feed: Feed): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/SaveFeedRepository.kt
@@ -1,12 +1,11 @@
 package com.example.mykku.member.repository
 
 import com.example.mykku.feed.domain.Feed
-import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SaveFeed
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface SaveFeedRepository : JpaRepository<SaveFeed, Long> {
-    fun existsByMemberAndFeed(member: Member, feed: Feed): Boolean
+    fun existsByMemberIdAndFeed(memberId: String, feed: Feed): Boolean
 }

--- a/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
@@ -10,6 +10,6 @@ class LikeFeedReader(
     private val likeFeedRepository: LikeFeedRepository,
 ) {
     fun isLiked(member: Member, feed: Feed): Boolean {
-        TODO("Not yet implemented")
+        return likeFeedRepository.existsByMemberAndFeed(member, feed)
     }
 }

--- a/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.member.tool
+
+import com.example.mykku.feed.domain.Feed
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.repository.LikeFeedRepository
+import org.springframework.stereotype.Component
+
+@Component
+class LikeFeedReader(
+    private val likeFeedRepository: LikeFeedRepository,
+) {
+    fun isLiked(member: Member, feed: Feed): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/LikeFeedReader.kt
@@ -1,7 +1,6 @@
 package com.example.mykku.member.tool
 
 import com.example.mykku.feed.domain.Feed
-import com.example.mykku.member.domain.Member
 import com.example.mykku.member.repository.LikeFeedRepository
 import org.springframework.stereotype.Component
 
@@ -9,7 +8,7 @@ import org.springframework.stereotype.Component
 class LikeFeedReader(
     private val likeFeedRepository: LikeFeedRepository,
 ) {
-    fun isLiked(member: Member, feed: Feed): Boolean {
-        return likeFeedRepository.existsByMemberAndFeed(member, feed)
+    fun isLiked(memberId: String, feed: Feed): Boolean {
+        return likeFeedRepository.existsByMemberIdAndFeed(memberId, feed)
     }
 }

--- a/src/main/kotlin/com/example/mykku/member/tool/MemberReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/MemberReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.member.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.repository.FollowRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MemberReader(
+    private val followRepository: FollowRepository
+) {
+    fun getFollowerByMemberId(memberId: String): List<Member> {
+        return followRepository.findByFollowerId(memberId)
+            .map { follow -> follow.following }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
@@ -10,6 +10,6 @@ class SaveFeedReader(
     private val saveFeedRepository: SaveFeedRepository,
 ) {
     fun isSaved(member: Member, feed: Feed): Boolean {
-        TODO("Not yet implemented")
+        return saveFeedRepository.existsByMemberAndFeed(member, feed)
     }
 }

--- a/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.member.tool
+
+import com.example.mykku.feed.domain.Feed
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.repository.SaveFeedRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SaveFeedReader(
+    private val saveFeedRepository: SaveFeedRepository,
+) {
+    fun isSaved(member: Member, feed: Feed): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/SaveFeedReader.kt
@@ -1,7 +1,6 @@
 package com.example.mykku.member.tool
 
 import com.example.mykku.feed.domain.Feed
-import com.example.mykku.member.domain.Member
 import com.example.mykku.member.repository.SaveFeedRepository
 import org.springframework.stereotype.Component
 
@@ -9,7 +8,7 @@ import org.springframework.stereotype.Component
 class SaveFeedReader(
     private val saveFeedRepository: SaveFeedRepository,
 ) {
-    fun isSaved(member: Member, feed: Feed): Boolean {
-        return saveFeedRepository.existsByMemberAndFeed(member, feed)
+    fun isSaved(memberId: String, feed: Feed): Boolean {
+        return saveFeedRepository.existsByMemberIdAndFeed(memberId, feed)
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #4 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 특정 회원의 피드를 조회하는 피드 관련 API 추가.
  - 작성자 정보, 이미지, 태그, 좋아요/저장 상태, 댓글 미리보기 포함한 상세 피드 응답 추가.
  - 회원 간 팔로우 관계 도입으로 팔로워 기반 피드 조회 기능 구현.

- **Improvements**
  - 엔티티 식별자 타입을 UUID에서 Long으로 변경하여 일관성과 통합성 향상.
  - 회원 프로필에 역할(role)과 프로필 이미지 속성 추가로 사용자 정보 강화.

- **Chores**
  - 서비스 어노테이션을 컴포넌트로 변경하여 일관성 유지.
  - 피드, 좋아요, 저장, 팔로우 기능 지원을 위한 새로운 리포지토리 인터페이스 및 리더 컴포넌트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->