### PR TITLE
[FEAT] 도메인 제한 사항 추가

### DIFF
--- a/src/main/kotlin/com/example/mykku/board/domain/Board.kt
+++ b/src/main/kotlin/com/example/mykku/board/domain/Board.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.board.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.example.mykku.feed.domain.Feed
 import jakarta.persistence.*
 
@@ -16,4 +18,13 @@ class Board(
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     val feeds: MutableList<Feed> = mutableListOf(),
 ) : BaseEntity() {
+    companion object {
+        const val TITLE_MAX_LENGTH = 16
+    }
+
+    init {
+        if (title.length > TITLE_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.BOARD_TITLE_TOO_LONG)
+        }
+    }
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.dailymessage.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import jakarta.persistence.*
 import java.time.LocalDate
 
@@ -19,4 +21,13 @@ class DailyMessage(
     @OneToMany(mappedBy = "dailyMessage", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     val comments: MutableList<DailyMessageComment> = mutableListOf(),
 ) : BaseEntity() {
+    companion object {
+        const val CONTENT_MAX_LENGTH = 42
+    }
+
+    init {
+        if (content.length > CONTENT_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.DAILY_MESSAGE_CONTENT_TOO_LONG)
+        }
+    }
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessageComment.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.dailymessage.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.example.mykku.member.domain.Member
 import jakarta.persistence.*
 
@@ -28,4 +30,13 @@ class DailyMessageComment(
     @JoinColumn(name = "member_id")
     val member: Member,
 ) : BaseEntity() {
+    companion object {
+        const val CONTENT_MAX_LENGTH = 1000
+    }
+
+    init {
+        if (content.length > CONTENT_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.DAILY_MESSAGE_COMMENT_CONTENT_TOO_LONG)
+        }
+    }
 }

--- a/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
@@ -1,7 +1,10 @@
 package com.example.mykku.exception
 
 import com.example.mykku.board.domain.Board
+import com.example.mykku.dailymessage.domain.DailyMessage
+import com.example.mykku.dailymessage.domain.DailyMessageComment
 import com.example.mykku.feed.domain.Feed
+import com.example.mykku.feed.domain.FeedComment
 import com.example.mykku.feed.domain.Tag
 import com.example.mykku.member.domain.Member
 import org.springframework.http.HttpStatus
@@ -9,6 +12,7 @@ import org.springframework.http.HttpStatus
 enum class ErrorCode(val status: HttpStatus, val message: String) {
     // Daily Message
     NOT_FOUND_DAILY_MESSAGE(HttpStatus.NOT_FOUND, "하루 덕담을 찾을 수 없습니다"),
+    DAILY_MESSAGE_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "하루 덕담은 ${DailyMessage.CONTENT_MAX_LENGTH}자 이하여야 합니다"),
 
     // Feed
     FEED_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "피드 내용은 ${Feed.CONTENT_MAX_LENGTH}자 이하여야 합니다"),
@@ -25,4 +29,8 @@ enum class ErrorCode(val status: HttpStatus, val message: String) {
     // Member
     MEMBER_NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임은 ${Member.NICKNAME_MAX_LENGTH}자 이하여야 합니다"),
     MEMBER_NICKNAME_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다"),
+
+    // Comment
+    FEED_COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "피드 댓글은 ${FeedComment.CONTENT_MAX_LENGTH}자 이하여야 합니다"),
+    DAILY_MESSAGE_COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "하루 덕담 댓글은 ${DailyMessageComment.CONTENT_MAX_LENGTH}자 이하여야 합니다"),
 }

--- a/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
@@ -1,7 +1,28 @@
 package com.example.mykku.exception
 
+import com.example.mykku.board.domain.Board
+import com.example.mykku.feed.domain.Feed
+import com.example.mykku.feed.domain.Tag
+import com.example.mykku.member.domain.Member
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(val status: HttpStatus, val message: String) {
+    // Daily Message
     NOT_FOUND_DAILY_MESSAGE(HttpStatus.NOT_FOUND, "하루 덕담을 찾을 수 없습니다"),
+
+    // Feed
+    FEED_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "피드 내용은 ${Feed.CONTENT_MAX_LENGTH}자 이하여야 합니다"),
+    FEED_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "피드 이미지는 ${Feed.IMAGE_MAX_COUNT}개 이하여야 합니다"),
+    FEED_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "피드 태그는 ${Feed.TAG_MAX_COUNT}개 이하여야 합니다"),
+
+    // Tag
+    TAG_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "태그는 ${Tag.TITLE_MAX_LENGTH}자 이하여야 합니다"),
+    TAG_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "태그는 한글, 영문, 숫자만 사용할 수 있습니다"),
+
+    // Board
+    BOARD_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "게시판 제목은 ${Board.TITLE_MAX_LENGTH}자 이하여야 합니다"),
+
+    // Member
+    MEMBER_NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임은 ${Member.NICKNAME_MAX_LENGTH}자 이하여야 합니다"),
+    MEMBER_NICKNAME_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다"),
 }

--- a/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Feed.kt
@@ -3,6 +3,8 @@ package com.example.mykku.feed.domain
 import com.example.mykku.board.domain.Board
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import jakarta.persistence.*
 
 @Entity
@@ -40,4 +42,21 @@ class Feed(
     @OneToMany(mappedBy = "feed", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     val feedTags: MutableList<FeedTag> = mutableListOf(),
 ) : BaseEntity() {
+    companion object {
+        const val CONTENT_MAX_LENGTH = 1000
+        const val IMAGE_MAX_COUNT = 10
+        const val TAG_MAX_COUNT = 7
+    }
+
+    init {
+        if (content.length > CONTENT_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.FEED_CONTENT_TOO_LONG)
+        }
+        if (feedImages.size > IMAGE_MAX_COUNT) {
+            throw MykkuException(ErrorCode.FEED_IMAGE_LIMIT_EXCEEDED)
+        }
+        if (feedTags.size > TAG_MAX_COUNT) {
+            throw MykkuException(ErrorCode.FEED_TAG_LIMIT_EXCEEDED)
+        }
+    }
 }

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedComment.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.feed.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.example.mykku.member.domain.Member
 import jakarta.persistence.*
 
@@ -27,4 +29,14 @@ class FeedComment(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: Member,
-) : BaseEntity()
+) : BaseEntity() {
+    companion object {
+        const val CONTENT_MAX_LENGTH = 1000
+    }
+
+    init {
+        if (content.length > CONTENT_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.FEED_COMMENT_CONTENT_TOO_LONG)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/Tag.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.feed.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import jakarta.persistence.*
@@ -23,5 +25,19 @@ abstract class Tag(
     @Column(name = "title")
     var title: String,
 ) : BaseEntity() {
+    companion object {
+        const val TITLE_MAX_LENGTH = 20
+        val VALID_PATTERN = Regex("^[가-힣a-zA-Z0-9]+$")
+    }
+
+    init {
+        if (title.length > TITLE_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.TAG_TITLE_TOO_LONG)
+        }
+        if (!VALID_PATTERN.matches(title)) {
+            throw MykkuException(ErrorCode.TAG_INVALID_FORMAT)
+        }
+    }
+
     abstract fun getType(): String
 }

--- a/src/main/kotlin/com/example/mykku/member/domain/Member.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/Member.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.member.domain
 
 import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import jakarta.persistence.*
 
 @Entity
@@ -29,4 +31,17 @@ class Member(
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     val saveDailyMessages: MutableList<SaveDailyMessage> = mutableListOf(),
 ) : BaseEntity() {
+    companion object {
+        const val NICKNAME_MAX_LENGTH = 10
+        val VALID_NICKNAME_PATTERN = Regex("^[가-힣a-zA-Z0-9]+$")
+    }
+
+    init {
+        if (nickname.length > NICKNAME_MAX_LENGTH) {
+            throw MykkuException(ErrorCode.MEMBER_NICKNAME_TOO_LONG)
+        }
+        if (!VALID_NICKNAME_PATTERN.matches(nickname)) {
+            throw MykkuException(ErrorCode.MEMBER_NICKNAME_INVALID_FORMAT)
+        }
+    }
 }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #11 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 게시판, 피드, 태그, 멤버, 데일리 메시지, 댓글 등 주요 항목에 대해 제목/내용/닉네임 길이 및 형식 제한이 추가되었습니다. 제한을 초과하거나 형식에 맞지 않을 경우 오류 메시지가 표시됩니다.
  - 피드 이미지 및 태그 개수에 대한 최대 개수 제한이 적용되었습니다.

- **버그 수정**
  - 입력값 유효성 검증이 강화되어 잘못된 입력에 대해 즉시 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->