### PR TITLE
[FEAT] DailyMessage 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.mockito.kotlin:mockito-kotlin")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,47 +1,48 @@
 plugins {
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.4.5"
-	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("plugin.jpa") version "1.9.25"
+    kotlin("jvm") version "1.9.25"
+    kotlin("plugin.spring") version "1.9.25"
+    id("org.springframework.boot") version "3.4.5"
+    id("io.spring.dependency-management") version "1.1.7"
+    kotlin("plugin.jpa") version "1.9.25"
 }
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	runtimeOnly("com.mysql:mysql-connector-j")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.mockito.kotlin:mockito-kotlin")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict")
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
 }
 
 allOpen {
-	annotation("jakarta.persistence.Entity")
-	annotation("jakarta.persistence.MappedSuperclass")
-	annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/controller/DailyMessageController.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/controller/DailyMessageController.kt
@@ -1,10 +1,14 @@
 package com.example.mykku.dailymessage.controller
 
+import com.example.mykku.common.dto.ApiResponse
 import com.example.mykku.dailymessage.domain.SortDirection
 import com.example.mykku.dailymessage.dto.DailyMessageResponse
+import com.example.mykku.dailymessage.dto.DailyMessageSummaryResponse
 import com.example.mykku.dailymessage.service.DailyMessageService
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
@@ -18,7 +22,28 @@ class DailyMessageController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
         @RequestParam(defaultValue = "10") limit: Int,
         @RequestParam(defaultValue = "DESC") sort: SortDirection
-    ): List<DailyMessageResponse> {
-        return dailyMessageService.getDailyMessages(date, limit, sort)
+    ): ResponseEntity<ApiResponse<List<DailyMessageSummaryResponse>>> {
+        val dailyMessages = dailyMessageService.getDailyMessages(date, limit, sort)
+
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "하루 덕담 리스트 불러오기에 성공했습니다.",
+                data = dailyMessages
+            )
+        )
+    }
+
+    @GetMapping("/api/v1/daily-messages/{id}")
+    fun getDailyMessage(
+        @PathVariable id: Long
+    ): ResponseEntity<ApiResponse<DailyMessageResponse>> {
+        val dailyMessage = dailyMessageService.getDailyMessage(id)
+
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "하루 덕담 데이터 불러오기에 성공했습니다.",
+                data = dailyMessage
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/controller/DailyMessageController.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/controller/DailyMessageController.kt
@@ -1,0 +1,24 @@
+package com.example.mykku.dailymessage.controller
+
+import com.example.mykku.dailymessage.domain.SortDirection
+import com.example.mykku.dailymessage.dto.DailyMessageResponse
+import com.example.mykku.dailymessage.service.DailyMessageService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+class DailyMessageController(
+    private val dailyMessageService: DailyMessageService
+) {
+    @GetMapping("/api/v1/daily-messages")
+    fun getDailyMessages(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @RequestParam(defaultValue = "10") limit: Int,
+        @RequestParam(defaultValue = "DESC") sort: SortDirection
+    ): List<DailyMessageResponse> {
+        return dailyMessageService.getDailyMessages(date, limit, sort)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/dailymessage/controller/converter/SortDirectionConverter.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/controller/converter/SortDirectionConverter.kt
@@ -1,0 +1,16 @@
+package com.example.mykku.dailymessage.controller.converter
+
+import com.example.mykku.dailymessage.domain.SortDirection
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+
+@Component
+class SortDirectionConverter : Converter<String, SortDirection> {
+    override fun convert(source: String): SortDirection {
+        return try {
+            SortDirection.valueOf(source.uppercase())
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Invalid sort direction: $source. Must be 'asc' or 'desc' (case insensitive)")
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/DailyMessage.kt
@@ -12,6 +12,9 @@ class DailyMessage(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
+    @Column(name = "title")
+    var title: String,
+
     @Column(name = "content")
     var content: String,
 

--- a/src/main/kotlin/com/example/mykku/dailymessage/domain/SortDirection.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/domain/SortDirection.kt
@@ -1,0 +1,6 @@
+package com.example.mykku.dailymessage.domain
+
+enum class SortDirection {
+    ASC,
+    DESC
+}

--- a/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageResponse.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageResponse.kt
@@ -1,0 +1,10 @@
+package com.example.mykku.dailymessage.dto
+
+import java.time.LocalDate
+
+data class DailyMessageResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val date: LocalDate
+)

--- a/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageResponse.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageResponse.kt
@@ -1,10 +1,28 @@
 package com.example.mykku.dailymessage.dto
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class DailyMessageResponse(
     val id: Long,
     val title: String,
     val content: String,
-    val date: LocalDate
+    val createdAt: LocalDateTime,
+    val comments: List<CommentResponse>
+)
+
+data class CommentResponse(
+    val id: Long,
+    val content: String,
+    val likeCount: Int,
+    val memberName: String,
+    val createdAt: LocalDateTime,
+    val replies: List<ReplyResponse>
+)
+
+data class ReplyResponse(
+    val id: Long,
+    val content: String,
+    val likeCount: Int,
+    val memberName: String,
+    val createdAt: LocalDateTime
 )

--- a/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageSummaryResponse.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/dto/DailyMessageSummaryResponse.kt
@@ -1,0 +1,10 @@
+package com.example.mykku.dailymessage.dto
+
+import java.time.LocalDate
+
+data class DailyMessageSummaryResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val date: LocalDate
+)

--- a/src/main/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepository.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepository.kt
@@ -1,11 +1,20 @@
 package com.example.mykku.dailymessage.repository
 
 import com.example.mykku.dailymessage.domain.DailyMessage
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
 @Repository
 interface DailyMessageRepository : JpaRepository<DailyMessage, Long> {
     fun findByDate(date: LocalDate): DailyMessage?
+    
+    @Query("SELECT dm FROM DailyMessage dm WHERE dm.date <= :date ORDER BY dm.date DESC")
+    fun findByDateBeforeOrEqualOrderByDateDesc(@Param("date") date: LocalDate, pageable: Pageable): List<DailyMessage>
+    
+    @Query("SELECT dm FROM DailyMessage dm WHERE dm.date <= :date ORDER BY dm.date ASC")
+    fun findByDateBeforeOrEqualOrderByDateAsc(@Param("date") date: LocalDate, pageable: Pageable): List<DailyMessage>
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/service/DailyMessageService.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/service/DailyMessageService.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.dailymessage.service
+
+import com.example.mykku.dailymessage.domain.DailyMessage
+import com.example.mykku.dailymessage.domain.SortDirection
+import com.example.mykku.dailymessage.dto.DailyMessageResponse
+import com.example.mykku.dailymessage.tool.DailyMessageReader
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class DailyMessageService(
+    private val dailyMessageReader: DailyMessageReader
+) {
+    fun getDailyMessages(date: LocalDate, limit: Int, sort: SortDirection): List<DailyMessageResponse> {
+        val dailyMessages = dailyMessageReader.getDailyMessages(date, limit, sort)
+
+        return dailyMessages.map { it.toResponse() }
+    }
+
+    private fun DailyMessage.toResponse(): DailyMessageResponse {
+        return DailyMessageResponse(
+            id = this.id!!,
+            title = this.title,
+            content = this.content,
+            date = this.date
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
@@ -1,9 +1,11 @@
 package com.example.mykku.dailymessage.tool
 
 import com.example.mykku.dailymessage.domain.DailyMessage
+import com.example.mykku.dailymessage.domain.SortDirection
 import com.example.mykku.dailymessage.repository.DailyMessageRepository
 import com.example.mykku.exception.ErrorCode
 import com.example.mykku.exception.MykkuException
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -14,5 +16,14 @@ class DailyMessageReader(
     fun getTodayDailyMessage(): DailyMessage {
         return dailyMessageRepository.findByDate(LocalDate.now())
             ?: throw MykkuException(ErrorCode.NOT_FOUND_DAILY_MESSAGE)
+    }
+
+    fun getDailyMessages(date: LocalDate, limit: Int, sort: SortDirection): List<DailyMessage> {
+        val pageable = PageRequest.of(0, limit)
+
+        return when (sort) {
+            SortDirection.ASC -> dailyMessageRepository.findByDateBeforeOrEqualOrderByDateAsc(date, pageable)
+            SortDirection.DESC -> dailyMessageRepository.findByDateBeforeOrEqualOrderByDateDesc(date, pageable)
+        }
     }
 }

--- a/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/tool/DailyMessageReader.kt
@@ -26,4 +26,10 @@ class DailyMessageReader(
             SortDirection.DESC -> dailyMessageRepository.findByDateBeforeOrEqualOrderByDateDesc(date, pageable)
         }
     }
+
+    fun getDailyMessage(id: Long): DailyMessage {
+        return dailyMessageRepository.findById(id).orElseThrow {
+            MykkuException(ErrorCode.NOT_FOUND_DAILY_MESSAGE)
+        }
+    }
 }

--- a/src/test/kotlin/com/example/mykku/dailymessage/domain/DailyMessageTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/domain/DailyMessageTest.kt
@@ -12,7 +12,8 @@ class DailyMessageTest {
         assertThrows<MykkuException> {
             DailyMessage(
                 content = "a".repeat(DailyMessage.CONTENT_MAX_LENGTH + 1),
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                title = "title"
             )
         }.apply {
             assert(this.errorCode == ErrorCode.DAILY_MESSAGE_CONTENT_TOO_LONG)


### PR DESCRIPTION
# 🚩 연관 이슈

closed #19 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 일일 메시지와 해당 댓글/답글을 조회할 수 있는 REST API 엔드포인트가 추가되었습니다.
  * 일일 메시지 요약 목록을 날짜, 정렬 방향, 개수로 조회할 수 있습니다.
  * 일일 메시지 상세 정보와 댓글, 답글을 함께 조회할 수 있습니다.
  * 정렬 방향(오름차순/내림차순) 선택 기능이 도입되었습니다.

* **버그 수정**
  * 일일 메시지 엔터티에 제목 필드가 추가되어 데이터 구조가 확장되었습니다.

* **테스트**
  * 새로운 의존성(mockito-kotlin)이 추가되었으며, 테스트 코드가 최신 데이터 구조에 맞게 보완되었습니다.

* **스타일**
  * 빌드 스크립트의 코드 정렬 및 들여쓰기가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->