### PR TITLE
[FEAT] 피드 관련 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    implementation("software.amazon.awssdk:s3:2.20.56")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -102,6 +102,14 @@ operation::home[snippets='http-request,http-response,response-fields']
 
 operation::feed-list[snippets='http-request,path-parameters,http-response,response-fields']
 
+=== 피드 작성
+
+operation::feed-create[snippets='http-request,request-headers,request-parts,http-response,response-fields']
+
+=== 피드 댓글 목록 조회
+
+operation::feed-comments-list[snippets='http-request,path-parameters,query-parameters,http-response,response-fields']
+
 [[board-api]]
 == 보드 API
 

--- a/src/main/kotlin/com/example/mykku/auth/tool/AppleOauthClient.kt
+++ b/src/main/kotlin/com/example/mykku/auth/tool/AppleOauthClient.kt
@@ -149,7 +149,7 @@ class AppleOauthClient(
             // JWT 헤더에서 kid (Key ID) 추출
             val header = extractJwtHeader(idToken)
             val kid = header["kid"] as? String 
-                ?: throw IllegalArgumentException("Missing kid in JWT header")
+                ?: throw MykkuException(ErrorCode.APPLE_JWT_HEADER_MISSING_KID)
             
             // Apple 공개 키 가져오기
             val publicKey = getApplePublicKey(kid)
@@ -174,7 +174,7 @@ class AppleOauthClient(
     private fun extractJwtHeader(idToken: String): Map<String, Any> {
         val parts = idToken.split(".")
         if (parts.size != 3) {
-            throw IllegalArgumentException("Invalid JWT token format")
+            throw MykkuException(ErrorCode.APPLE_JWT_INVALID_FORMAT)
         }
         
         val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
@@ -188,7 +188,7 @@ class AppleOauthClient(
         }
         
         return cachedAppleKeys[kid] 
-            ?: throw IllegalArgumentException("Public key not found for kid: $kid")
+            ?: throw MykkuException(ErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND)
     }
     
     private fun isCacheExpired(): Boolean {

--- a/src/main/kotlin/com/example/mykku/config/S3Config.kt
+++ b/src/main/kotlin/com/example/mykku/config/S3Config.kt
@@ -5,26 +5,34 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 
 @Configuration
 @EnableConfigurationProperties(S3Properties::class)
-@ConditionalOnProperty(name = ["aws.s3.enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["aws.s3.enabled"], havingValue = "true", matchIfMissing = false)
 class S3Config(
     private val s3Properties: S3Properties
 ) {
     @Bean
     fun s3Client(): S3Client {
-        val credentials = AwsBasicCredentials.create(
-            s3Properties.accessKey,
-            s3Properties.secretKey
-        )
-        
-        return S3Client.builder()
+        val builder = S3Client.builder()
             .region(Region.of(s3Properties.region))
-            .credentialsProvider(StaticCredentialsProvider.create(credentials))
-            .build()
+        
+        // accessKey와 secretKey가 설정되어 있으면 StaticCredentialsProvider 사용
+        // 그렇지 않으면 DefaultCredentialsProvider 사용 (환경변수, IAM 역할 등)
+        if (!s3Properties.accessKey.isNullOrBlank() && !s3Properties.secretKey.isNullOrBlank()) {
+            val credentials = AwsBasicCredentials.create(
+                s3Properties.accessKey,
+                s3Properties.secretKey
+            )
+            builder.credentialsProvider(StaticCredentialsProvider.create(credentials))
+        } else {
+            builder.credentialsProvider(DefaultCredentialsProvider.create())
+        }
+        
+        return builder.build()
     }
 }

--- a/src/main/kotlin/com/example/mykku/config/S3Config.kt
+++ b/src/main/kotlin/com/example/mykku/config/S3Config.kt
@@ -1,0 +1,30 @@
+package com.example.mykku.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+
+@Configuration
+@EnableConfigurationProperties(S3Properties::class)
+@ConditionalOnProperty(name = ["aws.s3.enabled"], havingValue = "true", matchIfMissing = true)
+class S3Config(
+    private val s3Properties: S3Properties
+) {
+    @Bean
+    fun s3Client(): S3Client {
+        val credentials = AwsBasicCredentials.create(
+            s3Properties.accessKey,
+            s3Properties.secretKey
+        )
+        
+        return S3Client.builder()
+            .region(Region.of(s3Properties.region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build()
+    }
+}

--- a/src/main/kotlin/com/example/mykku/config/S3Properties.kt
+++ b/src/main/kotlin/com/example/mykku/config/S3Properties.kt
@@ -4,8 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "aws.s3")
 data class S3Properties(
-    val accessKey: String,
-    val secretKey: String,
+    val accessKey: String? = null,
+    val secretKey: String? = null,
     val region: String,
     val bucketName: String
 )

--- a/src/main/kotlin/com/example/mykku/config/S3Properties.kt
+++ b/src/main/kotlin/com/example/mykku/config/S3Properties.kt
@@ -1,0 +1,11 @@
+package com.example.mykku.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "aws.s3")
+data class S3Properties(
+    val accessKey: String,
+    val secretKey: String,
+    val region: String,
+    val bucketName: String
+)

--- a/src/main/kotlin/com/example/mykku/dailymessage/controller/converter/SortDirectionConverter.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/controller/converter/SortDirectionConverter.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.dailymessage.controller.converter
 
 import com.example.mykku.dailymessage.domain.SortDirection
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
 
@@ -10,7 +12,7 @@ class SortDirectionConverter : Converter<String, SortDirection> {
         return try {
             SortDirection.valueOf(source.uppercase())
         } catch (e: IllegalArgumentException) {
-            throw IllegalArgumentException("Invalid sort direction: $source. Must be 'asc' or 'desc' (case insensitive)")
+            throw MykkuException(ErrorCode.INVALID_SORT_DIRECTION)
         }
     }
 }

--- a/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
@@ -66,6 +66,25 @@ enum class ErrorCode(val status: HttpStatus, val message: String) {
     OAUTH_INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다"),
     OAUTH_EXTERNAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "외부 서비스 오류가 발생했습니다"),
 
+    // Image Upload
+    IMAGE_FILE_EMPTY(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다"),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일 크기는 10MB 이하여야 합니다"),
+    IMAGE_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (지원 형식: jpeg, jpg, png, gif)"),
+    IMAGE_UNREADABLE(HttpStatus.BAD_REQUEST, "이미지를 읽을 수 없습니다"),
+    IMAGE_SIZE_EXTRACTION_FAILED(HttpStatus.BAD_REQUEST, "이미지 크기를 추출할 수 없습니다"),
+    IMAGE_UPLOAD_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "ImageUploadService가 구성되지 않았습니다. 이미지 업로드가 비활성화된 환경에서는 images를 비워 주세요."),
+
+    // Tag Creation
+    TAG_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "태그 생성 중 오류가 발생했습니다."),
+
+    // Apple OAuth
+    APPLE_JWT_HEADER_MISSING_KID(HttpStatus.BAD_REQUEST, "JWT 헤더에 kid가 없습니다"),
+    APPLE_JWT_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 JWT 토큰 형식입니다"),
+    APPLE_PUBLIC_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "공개 키를 찾을 수 없습니다"),
+
+    // Validation
+    INVALID_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "잘못된 정렬 방향입니다. 'asc' 또는 'desc'를 사용해주세요"),
+
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),

--- a/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
@@ -72,6 +72,7 @@ enum class ErrorCode(val status: HttpStatus, val message: String) {
     IMAGE_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (지원 형식: jpeg, jpg, png, gif)"),
     IMAGE_UNREADABLE(HttpStatus.BAD_REQUEST, "이미지를 읽을 수 없습니다"),
     IMAGE_SIZE_EXTRACTION_FAILED(HttpStatus.BAD_REQUEST, "이미지 크기를 추출할 수 없습니다"),
+    IMAGE_INVALID_DIMENSIONS(HttpStatus.BAD_REQUEST, "이미지 크기가 유효하지 않습니다"),
     IMAGE_UPLOAD_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "ImageUploadService가 구성되지 않았습니다. 이미지 업로드가 비활성화된 환경에서는 images를 비워 주세요."),
 
     // Tag Creation

--- a/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
@@ -2,27 +2,17 @@ package com.example.mykku.feed.controller
 
 import com.example.mykku.auth.config.CurrentMember
 import com.example.mykku.common.dto.ApiResponse
-import com.example.mykku.feed.dto.CreateFeedRequest
-import com.example.mykku.feed.dto.CreateFeedRequestDto
-import com.example.mykku.feed.dto.CreateFeedResponse
-import com.example.mykku.feed.dto.FeedCommentsResponse
-import com.example.mykku.feed.dto.FeedsResponse
+import com.example.mykku.feed.dto.*
 import com.example.mykku.feed.service.FeedCommentService
 import com.example.mykku.feed.service.FeedService
 import com.example.mykku.member.domain.Member
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.multipart.MultipartFile
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1")
@@ -43,7 +33,7 @@ class FeedController(
             images = images ?: emptyList(),
             tags = requestDto.tags
         )
-        
+
         val response = feedService.createFeed(request, member)
         return ResponseEntity.status(HttpStatus.CREATED).body(
             ApiResponse(
@@ -58,12 +48,12 @@ class FeedController(
         val feeds = feedService.getFeeds(memberId)
         return ResponseEntity.ok(
             ApiResponse(
-                message = "홈 피드 목록 불러오기에 성공했습니다.",
+                message = "피드 목록 불러오기에 성공했습니다.",
                 data = feeds
             )
         )
     }
-    
+
     @GetMapping("/feeds/{feedId}/comments")
     fun getComments(
         @PathVariable feedId: Long,

--- a/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
@@ -26,11 +26,18 @@ class FeedController(
         @RequestPart("images", required = false) images: List<MultipartFile>?,
         @CurrentMember member: Member
     ): ResponseEntity<ApiResponse<CreateFeedResponse>> {
+        val imageList = images ?: emptyList()
+        
+        // 이미지 개수 제한 검증
+        if (imageList.size > 10) {
+            throw IllegalArgumentException("이미지는 10개 이하여야 합니다.")
+        }
+        
         val request = CreateFeedRequest(
             title = requestDto.title,
             content = requestDto.content,
             boardId = requestDto.boardId,
-            images = images ?: emptyList(),
+            images = imageList,
             tags = requestDto.tags
         )
 

--- a/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/controller/FeedController.kt
@@ -1,18 +1,57 @@
 package com.example.mykku.feed.controller
 
+import com.example.mykku.auth.config.CurrentMember
 import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.feed.dto.CreateFeedRequest
+import com.example.mykku.feed.dto.CreateFeedRequestDto
+import com.example.mykku.feed.dto.CreateFeedResponse
 import com.example.mykku.feed.dto.FeedsResponse
 import com.example.mykku.feed.service.FeedService
+import com.example.mykku.member.domain.Member
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
+@RequestMapping("/api/v1")
 class FeedController(
     private val feedService: FeedService,
+    private val objectMapper: ObjectMapper
 ) {
-    @GetMapping("/api/v1/{memberId}/feeds")
+    @PostMapping("/feeds", consumes = ["multipart/form-data"])
+    fun createFeed(
+        @RequestPart("request") @Valid requestJson: String,
+        @RequestPart("images", required = false) images: List<MultipartFile>?,
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<CreateFeedResponse>> {
+        val requestDto = objectMapper.readValue(requestJson, CreateFeedRequestDto::class.java)
+        
+        val request = CreateFeedRequest(
+            title = requestDto.title,
+            content = requestDto.content,
+            boardId = requestDto.boardId,
+            images = images ?: emptyList(),
+            tags = requestDto.tags
+        )
+        
+        val response = feedService.createFeed(request, member)
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse(
+                message = "피드가 성공적으로 작성되었습니다.",
+                data = response
+            )
+        )
+    }
+
+    @GetMapping("/{memberId}/feeds")
     fun getFeeds(@PathVariable memberId: String): ResponseEntity<ApiResponse<FeedsResponse>> {
         val feeds = feedService.getFeeds(memberId)
         return ResponseEntity.ok(

--- a/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
+++ b/src/main/kotlin/com/example/mykku/feed/domain/FeedImage.kt
@@ -11,6 +11,12 @@ class FeedImage(
     @Column(name = "url")
     var url: String,
 
+    @Column(name = "width")
+    var width: Int,
+
+    @Column(name = "height")
+    var height: Int,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")
     val feed: Feed,

--- a/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequest.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequest.kt
@@ -1,0 +1,22 @@
+package com.example.mykku.feed.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.web.multipart.MultipartFile
+
+data class CreateFeedRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    
+    @field:NotBlank(message = "내용은 필수입니다")
+    @field:Size(max = 1000, message = "내용은 1000자 이하여야 합니다")
+    val content: String,
+    
+    val boardId: Long,
+    
+    @field:Size(max = 10, message = "이미지는 10개 이하여야 합니다")
+    val images: List<MultipartFile> = emptyList(),
+    
+    @field:Size(max = 7, message = "태그는 7개 이하여야 합니다")
+    val tags: List<String> = emptyList()
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequest.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequest.kt
@@ -9,14 +9,20 @@ data class CreateFeedRequest(
     val title: String,
     
     @field:NotBlank(message = "내용은 필수입니다")
-    @field:Size(max = 1000, message = "내용은 1000자 이하여야 합니다")
+    @field:Size(max = MAX_CONTENT_LENGTH, message = "내용은 ${MAX_CONTENT_LENGTH}자 이하여야 합니다")
     val content: String,
     
     val boardId: Long,
     
-    @field:Size(max = 10, message = "이미지는 10개 이하여야 합니다")
+    @field:Size(max = MAX_IMAGE_COUNT, message = "이미지는 ${MAX_IMAGE_COUNT}개 이하여야 합니다")
     val images: List<MultipartFile> = emptyList(),
     
-    @field:Size(max = 7, message = "태그는 7개 이하여야 합니다")
+    @field:Size(max = MAX_TAG_COUNT, message = "태그는 ${MAX_TAG_COUNT}개 이하여야 합니다")
     val tags: List<String> = emptyList()
-)
+) {
+    companion object {
+        const val MAX_CONTENT_LENGTH = 1000
+        const val MAX_IMAGE_COUNT = 10
+        const val MAX_TAG_COUNT = 7
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequestDto.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequestDto.kt
@@ -8,11 +8,16 @@ data class CreateFeedRequestDto(
     val title: String,
     
     @field:NotBlank(message = "내용은 필수입니다")
-    @field:Size(max = 1000, message = "내용은 1000자 이하여야 합니다")
+    @field:Size(max = MAX_CONTENT_LENGTH, message = "내용은 ${MAX_CONTENT_LENGTH}자 이하여야 합니다")
     val content: String,
     
     val boardId: Long,
     
-    @field:Size(max = 7, message = "태그는 7개 이하여야 합니다")
+    @field:Size(max = MAX_TAG_COUNT, message = "태그는 ${MAX_TAG_COUNT}개 이하여야 합니다")
     val tags: List<String> = emptyList()
-)
+) {
+    companion object {
+        const val MAX_CONTENT_LENGTH = 1000
+        const val MAX_TAG_COUNT = 7
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequestDto.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedRequestDto.kt
@@ -1,0 +1,18 @@
+package com.example.mykku.feed.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateFeedRequestDto(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    
+    @field:NotBlank(message = "내용은 필수입니다")
+    @field:Size(max = 1000, message = "내용은 1000자 이하여야 합니다")
+    val content: String,
+    
+    val boardId: Long,
+    
+    @field:Size(max = 7, message = "태그는 7개 이하여야 합니다")
+    val tags: List<String> = emptyList()
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/CreateFeedResponse.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.feed.dto
+
+import java.time.LocalDateTime
+
+data class CreateFeedResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val boardId: Long,
+    val boardTitle: String,
+    val authorId: String,
+    val authorNickname: String,
+    val authorProfileUrl: String?,
+    val images: List<FeedImageResponse>,
+    val tags: List<String>,
+    val likeCount: Int,
+    val commentCount: Int,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedCommentResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedCommentResponse.kt
@@ -1,0 +1,40 @@
+package com.example.mykku.feed.dto
+
+import java.time.LocalDateTime
+
+data class FeedCommentResponse(
+    val id: Long,
+    val content: String,
+    val author: CommentAuthorResponse,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    val replies: List<FeedCommentReplyResponse>,
+    val replyCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
+)
+
+data class CommentAuthorResponse(
+    val memberId: String,
+    val nickname: String,
+    val profileImage: String
+)
+
+data class FeedCommentReplyResponse(
+    val id: Long,
+    val content: String,
+    val author: CommentAuthorResponse,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
+)
+
+data class FeedCommentsResponse(
+    val comments: List<FeedCommentResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val pageSize: Int,
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedImageResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedImageResponse.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.feed.dto
+
+data class FeedImageResponse(
+    val url: String,
+    val width: Int,
+    val height: Int
+)

--- a/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/FeedResponse.kt
@@ -10,7 +10,7 @@ data class FeedResponse(
     val createdAt: LocalDateTime,
     val title: String,
     val content: String,
-    val images: List<String>,
+    val images: List<FeedImageResponse>,
     val tags: List<String>,
     val likeCount: Int,
     val isLiked: Boolean,
@@ -25,7 +25,13 @@ data class FeedResponse(
         createdAt = feed.createdAt,
         title = feed.title,
         content = feed.content,
-        images = feed.feedImages.map { it.url },
+        images = feed.feedImages.map { 
+            FeedImageResponse(
+                url = it.url,
+                width = it.width,
+                height = it.height
+            )
+        },
         tags = feed.feedTags.map { it.tag.title },
         likeCount = feed.likeCount,
         isLiked = isLiked,

--- a/src/main/kotlin/com/example/mykku/feed/repository/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/FeedCommentRepository.kt
@@ -11,11 +11,17 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
-    @Query("SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.feed = :feed AND fc.parentComment IS NULL ORDER BY fc.createdAt DESC")
+    @Query(
+        value = "SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.feed = :feed AND fc.parentComment IS NULL ORDER BY fc.createdAt DESC",
+        countQuery = "SELECT COUNT(fc) FROM FeedComment fc WHERE fc.feed = :feed AND fc.parentComment IS NULL"
+    )
     fun findByFeedAndParentCommentIsNull(@Param("feed") feed: Feed, pageable: Pageable): Page<FeedComment>
     
     @Query("SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.parentComment = :parentComment ORDER BY fc.createdAt ASC")
     fun findByParentComment(@Param("parentComment") parentComment: FeedComment): List<FeedComment>
+    
+    @Query("SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.parentComment IN :parentComments ORDER BY fc.parentComment.id, fc.createdAt ASC")
+    fun findByParentCommentIn(@Param("parentComments") parentComments: List<FeedComment>): List<FeedComment>
     
     fun countByFeed(feed: Feed): Long
 }

--- a/src/main/kotlin/com/example/mykku/feed/repository/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/FeedCommentRepository.kt
@@ -1,9 +1,21 @@
 package com.example.mykku.feed.repository
 
+import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.domain.FeedComment
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
+    @Query("SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.feed = :feed AND fc.parentComment IS NULL ORDER BY fc.createdAt DESC")
+    fun findByFeedAndParentCommentIsNull(@Param("feed") feed: Feed, pageable: Pageable): Page<FeedComment>
+    
+    @Query("SELECT fc FROM FeedComment fc JOIN FETCH fc.member WHERE fc.parentComment = :parentComment ORDER BY fc.createdAt ASC")
+    fun findByParentComment(@Param("parentComment") parentComment: FeedComment): List<FeedComment>
+    
+    fun countByFeed(feed: Feed): Long
 }

--- a/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
@@ -2,8 +2,9 @@ package com.example.mykku.feed.repository
 
 import com.example.mykku.feed.domain.Tag
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
+import org.springframework.stereotype.Repository
 
+@Repository
 interface TagRepository : JpaRepository<Tag, Long> {
-    fun findByTitle(title: String): Optional<Tag>
+    fun findByTitle(title: String): Tag?
 }

--- a/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface TagRepository : JpaRepository<Tag, Long> {
     fun findByTitle(title: String): Tag?
+    fun findAllByTitleIn(titles: Collection<String>): List<Tag>
 }

--- a/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
+++ b/src/main/kotlin/com/example/mykku/feed/repository/TagRepository.kt
@@ -1,0 +1,9 @@
+package com.example.mykku.feed.repository
+
+import com.example.mykku.feed.domain.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface TagRepository : JpaRepository<Tag, Long> {
+    fun findByTitle(title: String): Optional<Tag>
+}

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedCommentService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedCommentService.kt
@@ -19,8 +19,11 @@ class FeedCommentService(
         val feed = feedReader.getFeedById(feedId)
         val commentsPage = feedCommentReader.getCommentsByFeed(feed, pageable)
         
+        // 모든 부모 댓글의 대댓글을 한 번에 조회
+        val repliesMap = feedCommentReader.getRepliesByParentComments(commentsPage.content)
+        
         val commentResponses = commentsPage.content.map { comment ->
-            val replies = feedCommentReader.getRepliesByParentComment(comment)
+            val replies = repliesMap[comment.id] ?: emptyList()
             val replyResponses = replies.map { reply ->
                 FeedCommentReplyResponse(
                     id = reply.id!!,

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedCommentService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedCommentService.kt
@@ -1,0 +1,66 @@
+package com.example.mykku.feed.service
+
+import com.example.mykku.feed.dto.*
+import com.example.mykku.feed.tool.FeedCommentReader
+import com.example.mykku.feed.tool.FeedReader
+import com.example.mykku.like.tool.LikeFeedCommentReader
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class FeedCommentService(
+    private val feedReader: FeedReader,
+    private val feedCommentReader: FeedCommentReader,
+    private val likeFeedCommentReader: LikeFeedCommentReader
+) {
+    @Transactional(readOnly = true)
+    fun getComments(feedId: Long, memberId: String?, pageable: Pageable): FeedCommentsResponse {
+        val feed = feedReader.getFeedById(feedId)
+        val commentsPage = feedCommentReader.getCommentsByFeed(feed, pageable)
+        
+        val commentResponses = commentsPage.content.map { comment ->
+            val replies = feedCommentReader.getRepliesByParentComment(comment)
+            val replyResponses = replies.map { reply ->
+                FeedCommentReplyResponse(
+                    id = reply.id!!,
+                    content = reply.content,
+                    author = CommentAuthorResponse(
+                        memberId = reply.member.id,
+                        nickname = reply.member.nickname,
+                        profileImage = reply.member.profileImage
+                    ),
+                    likeCount = reply.likeCount,
+                    isLiked = memberId?.let { likeFeedCommentReader.isLiked(it, reply) } ?: false,
+                    createdAt = reply.createdAt,
+                    updatedAt = reply.updatedAt
+                )
+            }
+            
+            FeedCommentResponse(
+                id = comment.id!!,
+                content = comment.content,
+                author = CommentAuthorResponse(
+                    memberId = comment.member.id,
+                    nickname = comment.member.nickname,
+                    profileImage = comment.member.profileImage
+                ),
+                likeCount = comment.likeCount,
+                isLiked = memberId?.let { likeFeedCommentReader.isLiked(it, comment) } ?: false,
+                replies = replyResponses,
+                replyCount = replyResponses.size,
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt
+            )
+        }
+        
+        return FeedCommentsResponse(
+            comments = commentResponses,
+            totalElements = commentsPage.totalElements,
+            totalPages = commentsPage.totalPages,
+            currentPage = commentsPage.number,
+            pageSize = commentsPage.size,
+            hasNext = commentsPage.hasNext()
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.feed.service
 
 import com.example.mykku.board.tool.BoardReader
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.dto.AuthorResponse
 import com.example.mykku.feed.dto.CreateFeedRequest
@@ -33,10 +35,10 @@ class FeedService(
         val board = boardReader.getBoardById(request.boardId)
         
         // 이미지 파일들을 S3에 업로드하고 결과 받기
-        val imageResults = if (request.images.isNotEmpty() && imageUploadService != null) {
-            imageUploadService.uploadImages(request.images)
-        } else {
-            emptyList()
+        val imageResults = when {
+            request.images.isEmpty() -> emptyList()
+            imageUploadService != null -> imageUploadService.uploadImages(request.images)
+            else -> throw MykkuException(ErrorCode.IMAGE_UPLOAD_SERVICE_UNAVAILABLE)
         }
         
         val feed = feedWriter.createFeed(

--- a/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/example/mykku/feed/service/FeedService.kt
@@ -1,11 +1,18 @@
 package com.example.mykku.feed.service
 
+import com.example.mykku.board.tool.BoardReader
 import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.dto.AuthorResponse
+import com.example.mykku.feed.dto.CreateFeedRequest
+import com.example.mykku.feed.dto.CreateFeedResponse
+import com.example.mykku.feed.dto.FeedImageResponse
 import com.example.mykku.feed.dto.FeedResponse
 import com.example.mykku.feed.dto.FeedsResponse
 import com.example.mykku.feed.tool.FeedReader
+import com.example.mykku.feed.tool.FeedWriter
+import com.example.mykku.image.service.ImageUploadService
 import com.example.mykku.like.tool.LikeFeedReader
+import com.example.mykku.member.domain.Member
 import com.example.mykku.member.tool.MemberReader
 import com.example.mykku.member.tool.SaveFeedReader
 import org.springframework.stereotype.Service
@@ -14,10 +21,56 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class FeedService(
     private val feedReader: FeedReader,
+    private val feedWriter: FeedWriter,
+    private val boardReader: BoardReader,
     private val memberReader: MemberReader,
     private val likeFeedReader: LikeFeedReader,
-    private val saveFeedReader: SaveFeedReader
+    private val saveFeedReader: SaveFeedReader,
+    private val imageUploadService: ImageUploadService?
 ) {
+    @Transactional
+    fun createFeed(request: CreateFeedRequest, member: Member): CreateFeedResponse {
+        val board = boardReader.getBoardById(request.boardId)
+        
+        // 이미지 파일들을 S3에 업로드하고 결과 받기
+        val imageResults = if (request.images.isNotEmpty() && imageUploadService != null) {
+            imageUploadService.uploadImages(request.images)
+        } else {
+            emptyList()
+        }
+        
+        val feed = feedWriter.createFeed(
+            title = request.title,
+            content = request.content,
+            board = board,
+            member = member,
+            imageResults = imageResults,
+            tagTitles = request.tags
+        )
+        
+        return CreateFeedResponse(
+            id = feed.id!!,
+            title = feed.title,
+            content = feed.content,
+            boardId = board.id!!,
+            boardTitle = board.title,
+            authorId = member.id,
+            authorNickname = member.nickname,
+            authorProfileUrl = member.profileImage,
+            images = feed.feedImages.map { 
+                FeedImageResponse(
+                    url = it.url,
+                    width = it.width,
+                    height = it.height
+                )
+            },
+            tags = feed.feedTags.map { it.tag.title },
+            likeCount = feed.likeCount,
+            commentCount = feed.commentCount,
+            createdAt = feed.createdAt
+        )
+    }
+
     @Transactional(readOnly = true)
     fun getFeeds(memberId: String): FeedsResponse {
         val follower = memberReader.getFollowerByMemberId(memberId)

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedCommentReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedCommentReader.kt
@@ -2,16 +2,32 @@ package com.example.mykku.feed.tool
 
 import com.example.mykku.exception.ErrorCode
 import com.example.mykku.exception.MykkuException
+import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.domain.FeedComment
 import com.example.mykku.feed.repository.FeedCommentRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
 class FeedCommentReader(
     private val feedCommentRepository: FeedCommentRepository
 ) {
-    fun getFeedCommentById(feedCommentId: Long): FeedComment {
-        return feedCommentRepository.findById(feedCommentId)
-            .orElseThrow { MykkuException(ErrorCode.FEED_COMMENT_NOT_FOUND) }
+    fun getFeedCommentById(id: Long): FeedComment {
+        return feedCommentRepository.findByIdOrNull(id)
+            ?: throw MykkuException(ErrorCode.FEED_COMMENT_NOT_FOUND)
+    }
+    
+    fun getCommentsByFeed(feed: Feed, pageable: Pageable): Page<FeedComment> {
+        return feedCommentRepository.findByFeedAndParentCommentIsNull(feed, pageable)
+    }
+    
+    fun getRepliesByParentComment(parentComment: FeedComment): List<FeedComment> {
+        return feedCommentRepository.findByParentComment(parentComment)
+    }
+    
+    fun getCommentCount(feed: Feed): Long {
+        return feedCommentRepository.countByFeed(feed)
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedCommentReader.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedCommentReader.kt
@@ -27,6 +27,13 @@ class FeedCommentReader(
         return feedCommentRepository.findByParentComment(parentComment)
     }
     
+    fun getRepliesByParentComments(parentComments: List<FeedComment>): Map<Long, List<FeedComment>> {
+        if (parentComments.isEmpty()) return emptyMap()
+        
+        val allReplies = feedCommentRepository.findByParentCommentIn(parentComments)
+        return allReplies.groupBy { it.parentComment?.id ?: 0L }
+    }
+    
     fun getCommentCount(feed: Feed): Long {
         return feedCommentRepository.countByFeed(feed)
     }

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
@@ -11,6 +11,7 @@ import com.example.mykku.feed.repository.FeedRepository
 import com.example.mykku.feed.repository.TagRepository
 import com.example.mykku.image.dto.ImageUploadResult
 import com.example.mykku.member.domain.Member
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -20,6 +21,9 @@ class FeedWriter(
     private val feedRepository: FeedRepository,
     private val tagRepository: TagRepository
 ) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(FeedWriter::class.java)
+    }
     @Transactional
     fun createFeed(
         title: String,
@@ -36,7 +40,17 @@ class FeedWriter(
             member = member
         )
         
+        // 이미지 개수 제한 검증 (엔티티 생성 후 추가이므로 여기서 방어)
+        if (imageResults.size > Feed.IMAGE_MAX_COUNT) {
+            throw MykkuException(ErrorCode.FEED_IMAGE_LIMIT_EXCEEDED)
+        }
+        
         imageResults.forEach { imageResult ->
+            // 이미지 크기 검증
+            if (imageResult.width <= 0 || imageResult.height <= 0) {
+                throw MykkuException(ErrorCode.IMAGE_INVALID_DIMENSIONS)
+            }
+            
             val feedImage = FeedImage(
                 url = imageResult.url,
                 width = imageResult.width,
@@ -57,8 +71,12 @@ class FeedWriter(
             throw MykkuException(ErrorCode.FEED_TAG_LIMIT_EXCEEDED)
         }
 
+        // 배치 조회로 N+1 쿼리 최적화
+        val existingTagsByTitle = tagRepository.findAllByTitleIn(normalizedDistinctTags)
+            .associateBy { it.title }
+        
         normalizedDistinctTags.forEach { tagTitle ->
-            val tag = findOrCreateTag(tagTitle)
+            val tag = existingTagsByTitle[tagTitle] ?: findOrCreateTag(tagTitle)
             val feedTag = FeedTag(
                 feed = feed,
                 tag = tag
@@ -73,6 +91,7 @@ class FeedWriter(
         return tagRepository.findByTitle(title) ?: try {
             tagRepository.save(Tag(title = title))
         } catch (e: DataIntegrityViolationException) {
+            logger.debug("Tag creation failed due to constraint violation for title: '$title'", e)
             // 동시성 문제로 이미 태그가 생성된 경우 다시 조회
             tagRepository.findByTitle(title) 
                 ?: throw MykkuException(ErrorCode.TAG_CREATION_FAILED)

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
@@ -1,6 +1,8 @@
 package com.example.mykku.feed.tool
 
 import com.example.mykku.board.domain.Board
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
 import com.example.mykku.feed.domain.Feed
 import com.example.mykku.feed.domain.FeedImage
 import com.example.mykku.feed.domain.FeedTag
@@ -44,7 +46,13 @@ class FeedWriter(
             feed.feedImages.add(feedImage)
         }
         
-        tagTitles.forEach { tagTitle ->
+        val normalizedDistinctTags = tagTitles.asSequence()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .toList()
+
+        normalizedDistinctTags.forEach { tagTitle ->
             val tag = findOrCreateTag(tagTitle)
             val feedTag = FeedTag(
                 feed = feed,
@@ -62,7 +70,7 @@ class FeedWriter(
         } catch (e: DataIntegrityViolationException) {
             // 동시성 문제로 이미 태그가 생성된 경우 다시 조회
             tagRepository.findByTitle(title) 
-                ?: throw IllegalStateException("태그 생성 중 오류가 발생했습니다.")
+                ?: throw MykkuException(ErrorCode.TAG_CREATION_FAILED)
         }
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
+++ b/src/main/kotlin/com/example/mykku/feed/tool/FeedWriter.kt
@@ -52,6 +52,11 @@ class FeedWriter(
             .distinct()
             .toList()
 
+        // 태그 개수 제한 검증 (엔티티 생성 후 추가이므로 여기서 방어)
+        if (normalizedDistinctTags.size > Feed.TAG_MAX_COUNT) {
+            throw MykkuException(ErrorCode.FEED_TAG_LIMIT_EXCEEDED)
+        }
+
         normalizedDistinctTags.forEach { tagTitle ->
             val tag = findOrCreateTag(tagTitle)
             val feedTag = FeedTag(

--- a/src/main/kotlin/com/example/mykku/image/dto/ImageUploadResult.kt
+++ b/src/main/kotlin/com/example/mykku/image/dto/ImageUploadResult.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.image.dto
+
+data class ImageUploadResult(
+    val url: String,
+    val width: Int,
+    val height: Int
+)

--- a/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
+++ b/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
@@ -93,7 +93,7 @@ class ImageUploadService(
             
             Pair(bufferedImage.width, bufferedImage.height)
         } catch (e: Exception) {
-            throw IllegalArgumentException("이미지 크기를 추출할 수 없습니다: ${e.message}")
+            throw IllegalArgumentException("이미지 크기를 추출할 수 없습니다: ${e.message}", e)
         }
     }
 }

--- a/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
+++ b/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
@@ -1,0 +1,99 @@
+package com.example.mykku.image.service
+
+import com.example.mykku.config.S3Properties
+import com.example.mykku.image.dto.ImageUploadResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+import javax.imageio.ImageIO
+
+@Service
+@ConditionalOnProperty(name = ["aws.s3.enabled"], havingValue = "true", matchIfMissing = true)
+class ImageUploadService(
+    private val s3Client: S3Client,
+    private val s3Properties: S3Properties
+) {
+    companion object {
+        private val ALLOWED_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "webp")
+        private const val MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+    }
+    
+    fun uploadImages(images: List<MultipartFile>): List<ImageUploadResult> {
+        return images.map { uploadImage(it) }
+    }
+    
+    fun uploadImage(image: MultipartFile): ImageUploadResult {
+        validateImage(image)
+        
+        // 이미지 크기 추출
+        val imageBytes = image.bytes
+        val dimensions = extractImageDimensions(imageBytes)
+        
+        val fileName = generateFileName(image.originalFilename)
+        val key = "feed-images/$fileName"
+        
+        val putObjectRequest = PutObjectRequest.builder()
+            .bucket(s3Properties.bucketName)
+            .key(key)
+            .contentType(image.contentType)
+            .contentLength(image.size)
+            .build()
+        
+        s3Client.putObject(
+            putObjectRequest,
+            RequestBody.fromBytes(imageBytes)
+        )
+        
+        val url = "https://${s3Properties.bucketName}.s3.${s3Properties.region}.amazonaws.com/$key"
+        return ImageUploadResult(
+            url = url,
+            width = dimensions.first,
+            height = dimensions.second
+        )
+    }
+    
+    private fun validateImage(image: MultipartFile) {
+        if (image.isEmpty) {
+            throw IllegalArgumentException("이미지 파일이 비어있습니다")
+        }
+        
+        if (image.size > MAX_FILE_SIZE) {
+            throw IllegalArgumentException("이미지 파일 크기는 10MB 이하여야 합니다")
+        }
+        
+        val extension = getFileExtension(image.originalFilename)
+        if (extension !in ALLOWED_EXTENSIONS) {
+            throw IllegalArgumentException("지원하지 않는 이미지 형식입니다. (지원 형식: ${ALLOWED_EXTENSIONS.joinToString(", ")})")
+        }
+    }
+    
+    private fun generateFileName(originalFilename: String?): String {
+        val extension = getFileExtension(originalFilename)
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+        val uuid = UUID.randomUUID().toString().replace("-", "")
+        return "${timestamp}_${uuid}.$extension"
+    }
+    
+    private fun getFileExtension(filename: String?): String {
+        return filename?.substringAfterLast(".", "")?.lowercase() ?: ""
+    }
+    
+    private fun extractImageDimensions(imageBytes: ByteArray): Pair<Int, Int> {
+        return try {
+            val bufferedImage: BufferedImage = ImageIO.read(ByteArrayInputStream(imageBytes))
+                ?: throw IllegalArgumentException("이미지를 읽을 수 없습니다")
+            
+            Pair(bufferedImage.width, bufferedImage.height)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("이미지 크기를 추출할 수 없습니다: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
+++ b/src/main/kotlin/com/example/mykku/image/service/ImageUploadService.kt
@@ -96,6 +96,9 @@ class ImageUploadService(
                 ?: throw MykkuException(ErrorCode.IMAGE_UNREADABLE)
             
             Pair(bufferedImage.width, bufferedImage.height)
+        } catch (e: MykkuException) {
+            // 도메인 예외는 그대로 전달
+            throw e
         } catch (e: Exception) {
             throw MykkuException(ErrorCode.IMAGE_SIZE_EXTRACTION_FAILED)
         }

--- a/src/main/kotlin/com/example/mykku/like/tool/LikeFeedCommentReader.kt
+++ b/src/main/kotlin/com/example/mykku/like/tool/LikeFeedCommentReader.kt
@@ -2,6 +2,7 @@ package com.example.mykku.like.tool
 
 import com.example.mykku.exception.ErrorCode
 import com.example.mykku.exception.MykkuException
+import com.example.mykku.feed.domain.FeedComment
 import com.example.mykku.like.repository.LikeFeedCommentRepository
 import org.springframework.stereotype.Component
 
@@ -19,5 +20,9 @@ class LikeFeedCommentReader(
         if (!likeFeedCommentRepository.existsByMemberIdAndFeedCommentId(memberId, feedCommentId)) {
             throw MykkuException(ErrorCode.LIKE_FEED_COMMENT_NOT_FOUND)
         }
+    }
+    
+    fun isLiked(memberId: String, feedComment: FeedComment): Boolean {
+        return likeFeedCommentRepository.existsByMemberIdAndFeedCommentId(memberId, feedComment.id!!)
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS feed_image (
 -- Create Tag table
 CREATE TABLE IF NOT EXISTS tag (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(20) NOT NULL,
+    title VARCHAR(20) NOT NULL UNIQUE,
     created_at DATETIME(6) NOT NULL,
     updated_at DATETIME(6) NOT NULL
 );

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,3818 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>MyKKU API Documentation</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>MyKKU API Documentation</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#overview">개요</a>
+<ul class="sectlevel2">
+<li><a href="#_공통_응답_구조">공통 응답 구조</a></li>
+<li><a href="#_http_상태_코드">HTTP 상태 코드</a></li>
+</ul>
+</li>
+<li><a href="#auth-api">인증 API</a>
+<ul class="sectlevel2">
+<li><a href="#_구글_로그인">구글 로그인</a>
+<ul class="sectlevel3">
+<li><a href="#_구글_로그인_http_request">HTTP request</a></li>
+<li><a href="#_구글_로그인_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_구글_로그인_콜백">구글 로그인 콜백</a>
+<ul class="sectlevel3">
+<li><a href="#_구글_로그인_콜백_http_request">HTTP request</a></li>
+<li><a href="#_구글_로그인_콜백_query_parameters">Query parameters</a></li>
+<li><a href="#_구글_로그인_콜백_http_response">HTTP response</a></li>
+<li><a href="#_구글_로그인_콜백_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_카카오_로그인">카카오 로그인</a>
+<ul class="sectlevel3">
+<li><a href="#_카카오_로그인_http_request">HTTP request</a></li>
+<li><a href="#_카카오_로그인_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_카카오_로그인_콜백">카카오 로그인 콜백</a>
+<ul class="sectlevel3">
+<li><a href="#_카카오_로그인_콜백_http_request">HTTP request</a></li>
+<li><a href="#_카카오_로그인_콜백_query_parameters">Query parameters</a></li>
+<li><a href="#_카카오_로그인_콜백_http_response">HTTP response</a></li>
+<li><a href="#_카카오_로그인_콜백_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_애플_로그인">애플 로그인</a>
+<ul class="sectlevel3">
+<li><a href="#_애플_로그인_http_request">HTTP request</a></li>
+<li><a href="#_애플_로그인_query_parameters">Query parameters</a></li>
+<li><a href="#_애플_로그인_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_애플_로그인_콜백">애플 로그인 콜백</a>
+<ul class="sectlevel3">
+<li><a href="#_애플_로그인_콜백_http_request">HTTP request</a></li>
+<li><a href="#_애플_로그인_콜백_form_parameters">Form parameters</a></li>
+<li><a href="#_애플_로그인_콜백_http_response">HTTP response</a></li>
+<li><a href="#_애플_로그인_콜백_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#home-api">홈 API</a>
+<ul class="sectlevel2">
+<li><a href="#_홈_데이터_조회">홈 데이터 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_홈_데이터_조회_http_request">HTTP request</a></li>
+<li><a href="#_홈_데이터_조회_http_response">HTTP response</a></li>
+<li><a href="#_홈_데이터_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#feed-api">피드 API</a>
+<ul class="sectlevel2">
+<li><a href="#_피드_목록_조회">피드 목록 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_피드_목록_조회_http_request">HTTP request</a></li>
+<li><a href="#_피드_목록_조회_path_parameters">Path parameters</a></li>
+<li><a href="#_피드_목록_조회_http_response">HTTP response</a></li>
+<li><a href="#_피드_목록_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#board-api">보드 API</a>
+<ul class="sectlevel2">
+<li><a href="#_게시판_생성">게시판 생성</a>
+<ul class="sectlevel3">
+<li><a href="#_게시판_생성_http_request">HTTP request</a></li>
+<li><a href="#_게시판_생성_request_headers">Request headers</a></li>
+<li><a href="#_게시판_생성_request_fields">Request fields</a></li>
+<li><a href="#_게시판_생성_http_response">HTTP response</a></li>
+<li><a href="#_게시판_생성_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_게시판_수정">게시판 수정</a>
+<ul class="sectlevel3">
+<li><a href="#_게시판_수정_http_request">HTTP request</a></li>
+<li><a href="#_게시판_수정_path_parameters">Path parameters</a></li>
+<li><a href="#_게시판_수정_request_headers">Request headers</a></li>
+<li><a href="#_게시판_수정_request_fields">Request fields</a></li>
+<li><a href="#_게시판_수정_http_response">HTTP response</a></li>
+<li><a href="#_게시판_수정_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#daily-message-api">데일리 메시지 API</a>
+<ul class="sectlevel2">
+<li><a href="#_하루_덕담_목록_조회">하루 덕담 목록 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_목록_조회_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_목록_조회_query_parameters">Query parameters</a></li>
+<li><a href="#_하루_덕담_목록_조회_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_목록_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_상세_조회">하루 덕담 상세 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_상세_조회_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_상세_조회_path_parameters">Path parameters</a></li>
+<li><a href="#_하루_덕담_상세_조회_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_상세_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_댓글_생성">하루 덕담 댓글 생성</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_댓글_생성_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_댓글_생성_path_parameters">Path parameters</a></li>
+<li><a href="#_하루_덕담_댓글_생성_request_headers">Request headers</a></li>
+<li><a href="#_하루_덕담_댓글_생성_request_fields">Request fields</a></li>
+<li><a href="#_하루_덕담_댓글_생성_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_댓글_생성_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_답글_생성">하루 덕담 답글 생성</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_답글_생성_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_답글_생성_path_parameters">Path parameters</a></li>
+<li><a href="#_하루_덕담_답글_생성_request_headers">Request headers</a></li>
+<li><a href="#_하루_덕담_답글_생성_request_fields">Request fields</a></li>
+<li><a href="#_하루_덕담_답글_생성_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_답글_생성_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_댓글_수정">하루 덕담 댓글 수정</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_댓글_수정_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_댓글_수정_path_parameters">Path parameters</a></li>
+<li><a href="#_하루_덕담_댓글_수정_request_headers">Request headers</a></li>
+<li><a href="#_하루_덕담_댓글_수정_request_fields">Request fields</a></li>
+<li><a href="#_하루_덕담_댓글_수정_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_댓글_수정_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#like-api">좋아요 API</a>
+<ul class="sectlevel2">
+<li><a href="#_좋아요한_게시판_목록_조회">좋아요한 게시판 목록 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_좋아요한_게시판_목록_조회_http_request">HTTP request</a></li>
+<li><a href="#_좋아요한_게시판_목록_조회_request_headers">Request headers</a></li>
+<li><a href="#_좋아요한_게시판_목록_조회_http_response">HTTP response</a></li>
+<li><a href="#_좋아요한_게시판_목록_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_게시판_좋아요">게시판 좋아요</a>
+<ul class="sectlevel3">
+<li><a href="#_게시판_좋아요_http_request">HTTP request</a></li>
+<li><a href="#_게시판_좋아요_request_headers">Request headers</a></li>
+<li><a href="#_게시판_좋아요_request_fields">Request fields</a></li>
+<li><a href="#_게시판_좋아요_http_response">HTTP response</a></li>
+<li><a href="#_게시판_좋아요_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_게시판_좋아요_취소">게시판 좋아요 취소</a>
+<ul class="sectlevel3">
+<li><a href="#_게시판_좋아요_취소_http_request">HTTP request</a></li>
+<li><a href="#_게시판_좋아요_취소_path_parameters">Path parameters</a></li>
+<li><a href="#_게시판_좋아요_취소_request_headers">Request headers</a></li>
+<li><a href="#_게시판_좋아요_취소_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_피드_좋아요">피드 좋아요</a>
+<ul class="sectlevel3">
+<li><a href="#_피드_좋아요_http_request">HTTP request</a></li>
+<li><a href="#_피드_좋아요_request_headers">Request headers</a></li>
+<li><a href="#_피드_좋아요_request_fields">Request fields</a></li>
+<li><a href="#_피드_좋아요_http_response">HTTP response</a></li>
+<li><a href="#_피드_좋아요_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_피드_좋아요_취소">피드 좋아요 취소</a>
+<ul class="sectlevel3">
+<li><a href="#_피드_좋아요_취소_http_request">HTTP request</a></li>
+<li><a href="#_피드_좋아요_취소_path_parameters">Path parameters</a></li>
+<li><a href="#_피드_좋아요_취소_request_headers">Request headers</a></li>
+<li><a href="#_피드_좋아요_취소_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_댓글_좋아요">댓글 좋아요</a>
+<ul class="sectlevel3">
+<li><a href="#_댓글_좋아요_http_request">HTTP request</a></li>
+<li><a href="#_댓글_좋아요_request_headers">Request headers</a></li>
+<li><a href="#_댓글_좋아요_request_fields">Request fields</a></li>
+<li><a href="#_댓글_좋아요_http_response">HTTP response</a></li>
+<li><a href="#_댓글_좋아요_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_댓글_좋아요_취소">댓글 좋아요 취소</a>
+<ul class="sectlevel3">
+<li><a href="#_댓글_좋아요_취소_http_request">HTTP request</a></li>
+<li><a href="#_댓글_좋아요_취소_path_parameters">Path parameters</a></li>
+<li><a href="#_댓글_좋아요_취소_request_headers">Request headers</a></li>
+<li><a href="#_댓글_좋아요_취소_http_response">HTTP response</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_댓글_좋아요">하루 덕담 댓글 좋아요</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_댓글_좋아요_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_request_headers">Request headers</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_request_fields">Request fields</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_http_response">HTTP response</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_하루_덕담_댓글_좋아요_취소">하루 덕담 댓글 좋아요 취소</a>
+<ul class="sectlevel3">
+<li><a href="#_하루_덕담_댓글_좋아요_취소_http_request">HTTP request</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_취소_path_parameters">Path parameters</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_취소_request_headers">Request headers</a></li>
+<li><a href="#_하루_덕담_댓글_좋아요_취소_http_response">HTTP response</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#error-api">에러 응답</a>
+<ul class="sectlevel2">
+<li><a href="#_에러_응답_구조">에러 응답 구조</a></li>
+<li><a href="#_400_bad_request">400 Bad Request</a>
+<ul class="sectlevel3">
+<li><a href="#_400_bad_request_http_response">HTTP response</a></li>
+<li><a href="#_400_bad_request_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_404_not_found">404 Not Found</a>
+<ul class="sectlevel3">
+<li><a href="#_404_not_found_http_response">HTTP response</a></li>
+<li><a href="#_404_not_found_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_500_internal_server_error">500 Internal Server Error</a>
+<ul class="sectlevel3">
+<li><a href="#_500_internal_server_error_http_response">HTTP response</a></li>
+<li><a href="#_500_internal_server_error_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="overview"><a class="link" href="#overview">개요</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>MyKKU API 문서입니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_공통_응답_구조"><a class="link" href="#_공통_응답_구조">공통 응답 구조</a></h3>
+<div class="paragraph">
+<p>모든 API는 다음과 같은 공통 응답 구조를 가집니다:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-json hljs" data-lang="json">{
+  "message": "응답 메시지",
+  "data": {
+    // 응답 데이터
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_http_상태_코드"><a class="link" href="#_http_상태_코드">HTTP 상태 코드</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">상태 코드</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>200 OK</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 성공</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>400 Bad Request</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">잘못된 요청</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>401 Unauthorized</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증 실패</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>403 Forbidden</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">권한 없음</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>404 Not Found</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리소스를 찾을 수 없음</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>500 Internal Server Error</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 오류</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="auth-api"><a class="link" href="#auth-api">인증 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_구글_로그인"><a class="link" href="#_구글_로그인">구글 로그인</a></h3>
+<div class="paragraph">
+<p>구글 OAuth 로그인 페이지로 리다이렉트합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_http_request"><a class="link" href="#_구글_로그인_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/google/login HTTP/1.1
+Content-Type: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_http_response"><a class="link" href="#_구글_로그인_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 302 Found
+Content-Language: en
+Location: https://accounts.google.com/o/oauth2/v2/auth?client_id=test&amp;response_type=code&amp;scope=openid%20email%20profile&amp;redirect_uri=http://localhost:8080/api/v1/auth/google/callback&amp;access_type=offline</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_구글_로그인_콜백"><a class="link" href="#_구글_로그인_콜백">구글 로그인 콜백</a></h3>
+<div class="paragraph">
+<p>구글 OAuth 인증 후 콜백을 처리하고 JWT 토큰을 발급합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_콜백_http_request"><a class="link" href="#_구글_로그인_콜백_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/google/callback?code=google_auth_code_example HTTP/1.1
+Content-Type: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_콜백_query_parameters"><a class="link" href="#_구글_로그인_콜백_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">구글에서 제공받은 인증 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_콜백_http_response"><a class="link" href="#_구글_로그인_콜백_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 344
+
+{
+  "message" : "로그인 성공",
+  "data" : {
+    "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "tokenType" : "Bearer",
+    "expiresIn" : 86400000,
+    "member" : {
+      "id" : "testId",
+      "email" : "user@example.com",
+      "nickname" : "홍길동",
+      "profileImage" : "https://example.com/profile.jpg"
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_구글_로그인_콜백_response_fields"><a class="link" href="#_구글_로그인_콜백_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 액세스 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.tokenType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.expiresIn</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 만료 시간 (밀리초)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_카카오_로그인"><a class="link" href="#_카카오_로그인">카카오 로그인</a></h3>
+<div class="paragraph">
+<p>카카오 OAuth 로그인 페이지로 리다이렉트합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_http_request"><a class="link" href="#_카카오_로그인_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/kakao/login HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_http_response"><a class="link" href="#_카카오_로그인_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 302 Found
+Content-Language: en
+Location: https://kauth.kakao.com/oauth/authorize?client_id=test-client-id&amp;response_type=code&amp;redirect_uri=http://localhost:8080/api/v1/auth/kakao/callback</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_카카오_로그인_콜백"><a class="link" href="#_카카오_로그인_콜백">카카오 로그인 콜백</a></h3>
+<div class="paragraph">
+<p>카카오 OAuth 인증 후 콜백을 처리하고 JWT 토큰을 발급합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_콜백_http_request"><a class="link" href="#_카카오_로그인_콜백_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/kakao/callback?code=test-auth-code HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_콜백_query_parameters"><a class="link" href="#_카카오_로그인_콜백_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">카카오 OAuth 인증 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_콜백_http_response"><a class="link" href="#_카카오_로그인_콜백_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 255
+
+{"message":"로그인 성공","data":{"accessToken":"test-jwt-token","tokenType":"Bearer","expiresIn":86400000,"member":{"id":"kakao_123456789","email":"user@kakao.com","nickname":"카카오사용자","profileImage":"https://k.kakaocdn.net/profile.jpg"}}}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_카카오_로그인_콜백_response_fields"><a class="link" href="#_카카오_로그인_콜백_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 액세스 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.tokenType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.expiresIn</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 만료 시간 (밀리초)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일 주소</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_애플_로그인"><a class="link" href="#_애플_로그인">애플 로그인</a></h3>
+<div class="paragraph">
+<p>애플 OAuth 로그인 페이지로 리다이렉트합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_http_request"><a class="link" href="#_애플_로그인_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/apple/login?state=test-state HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_query_parameters"><a class="link" href="#_애플_로그인_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>state</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Apple OAuth state 파라미터 (선택사항)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_http_response"><a class="link" href="#_애플_로그인_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 302 Found
+Content-Language: en
+Location: https://appleid.apple.com/auth/authorize?client_id=test-client-id&amp;redirect_uri=http://localhost:8080/api/v1/auth/apple/callback&amp;response_type=code&amp;state=test-state&amp;scope=name%20email&amp;response_mode=form_post</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_애플_로그인_콜백"><a class="link" href="#_애플_로그인_콜백">애플 로그인 콜백</a></h3>
+<div class="paragraph">
+<p>애플 OAuth 인증 후 콜백을 처리하고 JWT 토큰을 발급합니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_콜백_http_request"><a class="link" href="#_애플_로그인_콜백_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/apple/callback HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: localhost:8080
+Content-Length: 36
+
+code=test-auth-code&amp;state=test-state</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_콜백_form_parameters"><a class="link" href="#_애플_로그인_콜백_form_parameters">Form parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Apple OAuth 인증 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>state</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Apple OAuth state 파라미터 (선택사항)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_콜백_http_response"><a class="link" href="#_애플_로그인_콜백_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 240
+
+{"message":"로그인 성공","data":{"accessToken":"test-jwt-token","tokenType":"Bearer","expiresIn":86400000,"member":{"id":"apple_000123.abc456def","email":"user@privaterelay.appleid.com","nickname":"애플사용자","profileImage":""}}}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_애플_로그인_콜백_response_fields"><a class="link" href="#_애플_로그인_콜백_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 액세스 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.tokenType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.expiresIn</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토큰 만료 시간 (밀리초)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.member.email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일 주소</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="home-api"><a class="link" href="#home-api">홈 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_홈_데이터_조회"><a class="link" href="#_홈_데이터_조회">홈 데이터 조회</a></h3>
+<div class="sect3">
+<h4 id="_홈_데이터_조회_http_request"><a class="link" href="#_홈_데이터_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/home HTTP/1.1
+Content-Type: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_홈_데이터_조회_http_response"><a class="link" href="#_홈_데이터_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 1635
+
+{
+  "message" : "홈 데이터 불러오기에 성공했습니다.",
+  "data" : {
+    "dailyMessage" : "오늘도 좋은 하루 되세요! 작은 일에도 감사하는 마음을 가져보세요.",
+    "events" : [ {
+      "id" : 1,
+      "images" : [ "https://example.com/event1-banner1.jpg", "https://example.com/event1-banner2.jpg" ]
+    }, {
+      "id" : 2,
+      "images" : [ "https://example.com/event2-banner1.jpg" ]
+    } ],
+    "feeds" : [ {
+      "id" : 1,
+      "board" : "자유게시판",
+      "title" : "첫 번째 인기 게시글",
+      "content" : "오늘 날씨가 정말 좋네요. 다들 좋은 하루 보내세요!",
+      "likeCount" : 123,
+      "commentCount" : 45
+    }, {
+      "id" : 2,
+      "board" : "질문게시판",
+      "title" : "React vs Vue 어떤 것이 좋을까요?",
+      "content" : "프론트엔드 프레임워크 선택에 대해 고민중입니다...",
+      "likeCount" : 89,
+      "commentCount" : 67
+    }, {
+      "id" : 3,
+      "board" : "정보공유",
+      "title" : "유용한 개발 도구 추천",
+      "content" : "최근에 발견한 생산성 향상 도구들을 공유합니다.",
+      "likeCount" : 156,
+      "commentCount" : 23
+    } ],
+    "contests" : [ {
+      "title" : "12월 사진 콘테스트",
+      "winners" : [ {
+        "id" : 1,
+        "image" : "https://example.com/contest-winner1.jpg",
+        "rank" : 1
+      }, {
+        "id" : 2,
+        "image" : "https://example.com/contest-winner2.jpg",
+        "rank" : 2
+      }, {
+        "id" : 3,
+        "image" : "https://example.com/contest-winner3.jpg",
+        "rank" : 3
+      } ]
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_홈_데이터_조회_response_fields"><a class="link" href="#_홈_데이터_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">홈 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dailyMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오늘의 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.events</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이벤트 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.events[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이벤트 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.events[].images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이벤트 배너 이미지 URL 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인기 피드 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].board</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 내용 미리보기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">콘테스트 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">콘테스트 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests[].winners</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">콘테스트 수상자 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests[].winners[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수상자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests[].winners[].image</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수상작 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contests[].winners[].rank</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">순위</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="feed-api"><a class="link" href="#feed-api">피드 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_피드_목록_조회"><a class="link" href="#_피드_목록_조회">피드 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_피드_목록_조회_http_request"><a class="link" href="#_피드_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/member123/feeds HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_목록_조회_path_parameters"><a class="link" href="#_피드_목록_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/{memberId}/feeds</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 회원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_목록_조회_http_response"><a class="link" href="#_피드_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 1472
+
+{
+  "message" : "홈 피드 목록 불러오기에 성공했습니다.",
+  "data" : {
+    "feeds" : [ {
+      "id" : 1,
+      "author" : {
+        "memberId" : "member123",
+        "nickname" : "닉네임1",
+        "profileImage" : "https://example.com/profile1.jpg",
+        "role" : "USER"
+      },
+      "board" : "자유게시판",
+      "createdAt" : "2024-01-01T12:00:00",
+      "title" : "첫 번째 피드 제목",
+      "content" : "첫 번째 피드 내용입니다.",
+      "images" : [ "https://example.com/image1.jpg", "https://example.com/image2.jpg" ],
+      "tags" : [ "태그1", "태그2" ],
+      "likeCount" : 10,
+      "isLiked" : true,
+      "isSaved" : false,
+      "commentCount" : 5,
+      "comment" : {
+        "profileImage" : "https://example.com/commenter1.jpg",
+        "content" : "첫 댓글입니다."
+      }
+    }, {
+      "id" : 2,
+      "author" : {
+        "memberId" : "member123",
+        "nickname" : "닉네임2",
+        "profileImage" : "https://example.com/profile2.jpg",
+        "role" : "USER"
+      },
+      "board" : "질문게시판",
+      "createdAt" : "2024-01-02T13:30:00",
+      "title" : "두 번째 피드 제목",
+      "content" : "두 번째 피드 내용입니다.",
+      "images" : [ ],
+      "tags" : [ "태그3" ],
+      "likeCount" : 20,
+      "isLiked" : false,
+      "isSaved" : true,
+      "commentCount" : 3,
+      "comment" : {
+        "profileImage" : "",
+        "content" : ""
+      }
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_목록_조회_response_fields"><a class="link" href="#_피드_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].author</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].author.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].author.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].author.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 프로필 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].author.role</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].board</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 이미지 URL 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].tags</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 태그 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].isLiked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자의 좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].isSaved</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자의 저장 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].comment</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">첫 댓글 미리보기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].comment.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 작성자 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].comment.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="board-api"><a class="link" href="#board-api">보드 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_게시판_생성"><a class="link" href="#_게시판_생성">게시판 생성</a></h3>
+<div class="sect3">
+<h4 id="_게시판_생성_http_request"><a class="link" href="#_게시판_생성_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/board HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 84
+Host: api.mykku.com
+
+{
+  "title" : "자유게시판",
+  "logo" : "https://api.mykku.com/board-logo.png"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_생성_request_headers"><a class="link" href="#_게시판_생성_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_생성_request_fields"><a class="link" href="#_게시판_생성_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>logo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 로고 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_생성_http_response"><a class="link" href="#_게시판_생성_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 186
+
+{
+  "message" : "게시판이 성공적으로 생성되었습니다.",
+  "data" : {
+    "id" : 1,
+    "title" : "자유게시판",
+    "logo" : "https://example.com/board-logo.png"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_생성_response_fields"><a class="link" href="#_게시판_생성_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 게시판 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.logo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 로고 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_게시판_수정"><a class="link" href="#_게시판_수정">게시판 수정</a></h3>
+<div class="sect3">
+<h4 id="_게시판_수정_http_request"><a class="link" href="#_게시판_수정_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/board/1 HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 90
+Host: api.mykku.com
+
+{
+  "title" : "수정된 게시판",
+  "logo" : "https://api.mykku.com/updated-logo.png"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_수정_path_parameters"><a class="link" href="#_게시판_수정_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/board/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 게시판 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_수정_request_headers"><a class="link" href="#_게시판_수정_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_수정_request_fields"><a class="link" href="#_게시판_수정_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>logo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 로고 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_수정_http_response"><a class="link" href="#_게시판_수정_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 192
+
+{
+  "message" : "게시판이 성공적으로 수정되었습니다.",
+  "data" : {
+    "id" : 1,
+    "title" : "수정된 게시판",
+    "logo" : "https://example.com/updated-logo.png"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_수정_response_fields"><a class="link" href="#_게시판_수정_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.logo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 로고 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="daily-message-api"><a class="link" href="#daily-message-api">데일리 메시지 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_하루_덕담_목록_조회"><a class="link" href="#_하루_덕담_목록_조회">하루 덕담 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_목록_조회_http_request"><a class="link" href="#_하루_덕담_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/daily-messages?date=2024-01-01&amp;limit=10&amp;sort=DESC HTTP/1.1
+Content-Type: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_목록_조회_query_parameters"><a class="link" href="#_하루_덕담_목록_조회_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>date</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 날짜 (YYYY-MM-DD 형식)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 개수 (기본값: 10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 방향 (ASC/DESC, 기본값: DESC)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_목록_조회_http_response"><a class="link" href="#_하루_덕담_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 394
+
+{
+  "message" : "하루 덕담 리스트 불러오기에 성공했습니다.",
+  "data" : [ {
+    "id" : 1,
+    "title" : "새해 첫날의 덕담",
+    "content" : "새해 복 많이 받으세요!",
+    "date" : "2024-01-01"
+  }, {
+    "id" : 2,
+    "title" : "희망찬 새해",
+    "content" : "2024년에는 모든 소망이 이루어지길 바랍니다.",
+    "date" : "2024-01-01"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_목록_조회_response_fields"><a class="link" href="#_하루_덕담_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].date</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 날짜</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_상세_조회"><a class="link" href="#_하루_덕담_상세_조회">하루 덕담 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_상세_조회_http_request"><a class="link" href="#_하루_덕담_상세_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/daily-message/1 HTTP/1.1
+Content-Type: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_상세_조회_path_parameters"><a class="link" href="#_하루_덕담_상세_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/daily-message/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 하루 덕담 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_상세_조회_http_response"><a class="link" href="#_하루_덕담_상세_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 932
+
+{
+  "message" : "하루 덕담 데이터 불러오기에 성공했습니다.",
+  "data" : {
+    "id" : 1,
+    "title" : "새해 첫날의 덕담",
+    "content" : "새해 복 많이 받으세요! 올 한해도 건강하고 행복하시길 바랍니다.",
+    "createdAt" : "2024-01-01T00:00:00",
+    "comments" : [ {
+      "id" : 1,
+      "content" : "감사합니다! 새해 복 많이 받으세요!",
+      "likeCount" : 5,
+      "memberName" : "사용자1",
+      "createdAt" : "2024-01-01T10:30:00",
+      "replies" : [ {
+        "id" : 1,
+        "content" : "함께 좋은 한 해 만들어요!",
+        "likeCount" : 2,
+        "memberName" : "사용자2",
+        "createdAt" : "2024-01-01T11:00:00"
+      } ]
+    }, {
+      "id" : 2,
+      "content" : "좋은 덕담 감사합니다.",
+      "likeCount" : 3,
+      "memberName" : "사용자3",
+      "createdAt" : "2024-01-01T12:00:00",
+      "replies" : [ ]
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_상세_조회_response_fields"><a class="link" href="#_하루_덕담_상세_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 상세 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_댓글_생성"><a class="link" href="#_하루_덕담_댓글_생성">하루 덕담 댓글 생성</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_http_request"><a class="link" href="#_하루_덕담_댓글_생성_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/daily-messages/1/comment HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 78
+Host: api.mykku.com
+
+{
+  "content" : "좋은 덕담 감사합니다!",
+  "parentCommentId" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_path_parameters"><a class="link" href="#_하루_덕담_댓글_생성_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/daily-messages/{dailyMessageId}/comment</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailyMessageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글을 작성할 하루 덕담 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_request_headers"><a class="link" href="#_하루_덕담_댓글_생성_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_request_fields"><a class="link" href="#_하루_덕담_댓글_생성_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>parentCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">부모 댓글 ID (답글인 경우)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_http_response"><a class="link" href="#_하루_덕담_댓글_생성_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 264
+
+{
+  "message" : "댓글이 성공적으로 등록되었습니다.",
+  "data" : {
+    "id" : 1,
+    "content" : "좋은 덕담 감사합니다!",
+    "likeCount" : 0,
+    "memberName" : "홍길동",
+    "createdAt" : "2024-01-01T14:30:00",
+    "replies" : [ ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_생성_response_fields"><a class="link" href="#_하루_덕담_댓글_생성_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 댓글 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.replies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 목록</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_답글_생성"><a class="link" href="#_하루_덕담_답글_생성">하루 덕담 답글 생성</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_http_request"><a class="link" href="#_하루_덕담_답글_생성_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/daily-messages/1/comment HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 69
+Host: api.mykku.com
+
+{
+  "content" : "저도 동감합니다!",
+  "parentCommentId" : 10
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_path_parameters"><a class="link" href="#_하루_덕담_답글_생성_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/daily-messages/{dailyMessageId}/comment</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailyMessageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글을 작성할 하루 덕담 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_request_headers"><a class="link" href="#_하루_덕담_답글_생성_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_request_fields"><a class="link" href="#_하루_덕담_답글_생성_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>parentCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">부모 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_http_response"><a class="link" href="#_하루_덕담_답글_생성_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 257
+
+{
+  "message" : "댓글이 성공적으로 등록되었습니다.",
+  "data" : {
+    "id" : 2,
+    "content" : "저도 동감합니다!",
+    "likeCount" : 0,
+    "memberName" : "김철수",
+    "createdAt" : "2024-01-01T15:00:00",
+    "replies" : [ ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_답글_생성_response_fields"><a class="link" href="#_하루_덕담_답글_생성_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 답글 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.replies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 목록 (항상 빈 배열)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_댓글_수정"><a class="link" href="#_하루_덕담_댓글_수정">하루 덕담 댓글 수정</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_http_request"><a class="link" href="#_하루_덕담_댓글_수정_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/daily-messages/comments/1 HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 53
+Host: api.mykku.com
+
+{
+  "content" : "수정된 댓글 내용입니다!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_path_parameters"><a class="link" href="#_하루_덕담_댓글_수정_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/daily-messages/comments/{commentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_request_headers"><a class="link" href="#_하루_덕담_댓글_수정_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_request_fields"><a class="link" href="#_하루_덕담_댓글_수정_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 댓글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_http_response"><a class="link" href="#_하루_덕담_댓글_수정_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 267
+
+{
+  "message" : "댓글이 성공적으로 수정되었습니다.",
+  "data" : {
+    "id" : 1,
+    "content" : "수정된 댓글 내용입니다!",
+    "likeCount" : 5,
+    "memberName" : "홍길동",
+    "createdAt" : "2024-01-01T14:30:00",
+    "replies" : [ ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_수정_response_fields"><a class="link" href="#_하루_덕담_댓글_수정_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정된 댓글 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.replies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">답글 목록</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="like-api"><a class="link" href="#like-api">좋아요 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_좋아요한_게시판_목록_조회"><a class="link" href="#_좋아요한_게시판_목록_조회">좋아요한 게시판 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_좋아요한_게시판_목록_조회_http_request"><a class="link" href="#_좋아요한_게시판_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/boards/like HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_좋아요한_게시판_목록_조회_request_headers"><a class="link" href="#_좋아요한_게시판_목록_조회_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_좋아요한_게시판_목록_조회_http_response"><a class="link" href="#_좋아요한_게시판_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 421
+
+{
+  "message" : "즐겨찾기한 게시판 목록을 성공적으로 조회하였습니다.",
+  "data" : [ {
+    "id" : 1,
+    "title" : "자유게시판",
+    "logo" : "https://example.com/board1-logo.png"
+  }, {
+    "id" : 2,
+    "title" : "질문게시판",
+    "logo" : "https://example.com/board2-logo.png"
+  }, {
+    "id" : 3,
+    "title" : "정보공유",
+    "logo" : "https://example.com/board3-logo.png"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_좋아요한_게시판_목록_조회_response_fields"><a class="link" href="#_좋아요한_게시판_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">즐겨찾기한 게시판 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].logo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 로고 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_게시판_좋아요"><a class="link" href="#_게시판_좋아요">게시판 좋아요</a></h3>
+<div class="sect3">
+<h4 id="_게시판_좋아요_http_request"><a class="link" href="#_게시판_좋아요_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/board/like HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 19
+Host: api.mykku.com
+
+{
+  "boardId" : 1
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_request_headers"><a class="link" href="#_게시판_좋아요_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_request_fields"><a class="link" href="#_게시판_좋아요_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">즐겨찾기할 게시판 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_http_response"><a class="link" href="#_게시판_좋아요_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 164
+
+{
+  "message" : "게시판 즐겨찾기가 성공적으로 처리되었습니다.",
+  "data" : {
+    "id" : 1,
+    "memberId" : "member123",
+    "boardId" : 1
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_response_fields"><a class="link" href="#_게시판_좋아요_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 좋아요 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_게시판_좋아요_취소"><a class="link" href="#_게시판_좋아요_취소">게시판 좋아요 취소</a></h3>
+<div class="sect3">
+<h4 id="_게시판_좋아요_취소_http_request"><a class="link" href="#_게시판_좋아요_취소_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/board/unlike/1 HTTP/1.1
+Authorization: Bearer jwt-token
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_취소_path_parameters"><a class="link" href="#_게시판_좋아요_취소_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/board/unlike/{boardId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">즐겨찾기 취소할 게시판 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_취소_request_headers"><a class="link" href="#_게시판_좋아요_취소_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_게시판_좋아요_취소_http_response"><a class="link" href="#_게시판_좋아요_취소_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_피드_좋아요"><a class="link" href="#_피드_좋아요">피드 좋아요</a></h3>
+<div class="sect3">
+<h4 id="_피드_좋아요_http_request"><a class="link" href="#_피드_좋아요_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/feed/like HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 19
+Host: api.mykku.com
+
+{
+  "feedId" : 10
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_request_headers"><a class="link" href="#_피드_좋아요_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_request_fields"><a class="link" href="#_피드_좋아요_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>feedId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요할 피드 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_http_response"><a class="link" href="#_피드_좋아요_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 158
+
+{
+  "message" : "피드 좋아요가 성공적으로 처리되었습니다.",
+  "data" : {
+    "id" : 1,
+    "memberId" : "member123",
+    "feedId" : 10
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_response_fields"><a class="link" href="#_피드_좋아요_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 좋아요 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feedId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_피드_좋아요_취소"><a class="link" href="#_피드_좋아요_취소">피드 좋아요 취소</a></h3>
+<div class="sect3">
+<h4 id="_피드_좋아요_취소_http_request"><a class="link" href="#_피드_좋아요_취소_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/feed/unlike/10 HTTP/1.1
+Authorization: Bearer jwt-token
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_취소_path_parameters"><a class="link" href="#_피드_좋아요_취소_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/feed/unlike/{feedId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>feedId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 취소할 피드 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_취소_request_headers"><a class="link" href="#_피드_좋아요_취소_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_좋아요_취소_http_response"><a class="link" href="#_피드_좋아요_취소_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_좋아요"><a class="link" href="#_댓글_좋아요">댓글 좋아요</a></h3>
+<div class="sect3">
+<h4 id="_댓글_좋아요_http_request"><a class="link" href="#_댓글_좋아요_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/comment/like HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 26
+Host: api.mykku.com
+
+{
+  "feedCommentId" : 20
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_request_headers"><a class="link" href="#_댓글_좋아요_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_request_fields"><a class="link" href="#_댓글_좋아요_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>feedCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_http_response"><a class="link" href="#_댓글_좋아요_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 165
+
+{
+  "message" : "댓글 좋아요가 성공적으로 처리되었습니다.",
+  "data" : {
+    "id" : 1,
+    "memberId" : "member123",
+    "feedCommentId" : 20
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_response_fields"><a class="link" href="#_댓글_좋아요_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 좋아요 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feedCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_좋아요_취소"><a class="link" href="#_댓글_좋아요_취소">댓글 좋아요 취소</a></h3>
+<div class="sect3">
+<h4 id="_댓글_좋아요_취소_http_request"><a class="link" href="#_댓글_좋아요_취소_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/comment/unlike/20 HTTP/1.1
+Authorization: Bearer jwt-token
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_취소_path_parameters"><a class="link" href="#_댓글_좋아요_취소_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/comment/unlike/{feedCommentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>feedCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 취소할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_취소_request_headers"><a class="link" href="#_댓글_좋아요_취소_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_댓글_좋아요_취소_http_response"><a class="link" href="#_댓글_좋아요_취소_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_댓글_좋아요"><a class="link" href="#_하루_덕담_댓글_좋아요">하루 덕담 댓글 좋아요</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_http_request"><a class="link" href="#_하루_덕담_댓글_좋아요_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/daily-message-comment/like HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer jwt-token
+Content-Length: 34
+Host: api.mykku.com
+
+{
+  "dailyMessageCommentId" : 30
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_request_headers"><a class="link" href="#_하루_덕담_댓글_좋아요_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_request_fields"><a class="link" href="#_하루_덕담_댓글_좋아요_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailyMessageCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요할 하루 덕담 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_http_response"><a class="link" href="#_하루_덕담_댓글_좋아요_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 173
+
+{
+  "message" : "댓글 좋아요가 성공적으로 처리되었습니다.",
+  "data" : {
+    "id" : 1,
+    "memberId" : "member123",
+    "dailyMessageCommentId" : 30
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_response_fields"><a class="link" href="#_하루_덕담_댓글_좋아요_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 좋아요 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dailyMessageCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">하루 덕담 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_하루_덕담_댓글_좋아요_취소"><a class="link" href="#_하루_덕담_댓글_좋아요_취소">하루 덕담 댓글 좋아요 취소</a></h3>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_취소_http_request"><a class="link" href="#_하루_덕담_댓글_좋아요_취소_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/daily-message-comment/unlike/30 HTTP/1.1
+Authorization: Bearer jwt-token
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_취소_path_parameters"><a class="link" href="#_하루_덕담_댓글_좋아요_취소_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/daily-message-comment/unlike/{dailyMessageCommentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailyMessageCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 취소할 하루 덕담 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_취소_request_headers"><a class="link" href="#_하루_덕담_댓글_좋아요_취소_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 인증 토큰 (Bearer {token})</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_하루_덕담_댓글_좋아요_취소_http_response"><a class="link" href="#_하루_덕담_댓글_좋아요_취소_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="error-api"><a class="link" href="#error-api">에러 응답</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>MyKKU API는 에러 발생 시 일관된 형식의 에러 응답을 반환합니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_에러_응답_구조"><a class="link" href="#_에러_응답_구조">에러 응답 구조</a></h3>
+<div class="paragraph">
+<p>모든 에러 응답은 다음과 같은 구조를 가집니다:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-json hljs" data-lang="json">{
+  "message": "에러 메시지"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_400_bad_request"><a class="link" href="#_400_bad_request">400 Bad Request</a></h3>
+<div class="paragraph">
+<p>요청이 잘못된 경우 반환됩니다. 예: 중복된 데이터, 유효하지 않은 입력값 등</p>
+</div>
+<div class="sect3">
+<h4 id="_400_bad_request_http_response"><a class="link" href="#_400_bad_request_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 65
+
+{
+  "message" : "이미 존재하는 게시판 제목입니다"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_400_bad_request_response_fields"><a class="link" href="#_400_bad_request_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="paragraph">
+<p>예시:
+- 이미 존재하는 게시판 제목으로 생성 시도
+- 이미 좋아요한 피드에 다시 좋아요 시도
+- 입력값이 제한 길이를 초과하는 경우</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_404_not_found"><a class="link" href="#_404_not_found">404 Not Found</a></h3>
+<div class="paragraph">
+<p>요청한 리소스를 찾을 수 없는 경우 반환됩니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_404_not_found_http_response"><a class="link" href="#_404_not_found_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "게시판을 찾을 수 없습니다"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_404_not_found_response_fields"><a class="link" href="#_404_not_found_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="paragraph">
+<p>예시:
+- 존재하지 않는 게시판 ID로 조회
+- 존재하지 않는 피드 ID로 조회
+- 삭제된 댓글에 접근 시도</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_500_internal_server_error"><a class="link" href="#_500_internal_server_error">500 Internal Server Error</a></h3>
+<div class="paragraph">
+<p>서버 내부 오류가 발생한 경우 반환됩니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_500_internal_server_error_http_response"><a class="link" href="#_500_internal_server_error_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
+Content-Length: 92
+
+{
+  "message" : "서버 오류가 발생했습니다. 관리자에게 문의해주세요."
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_500_internal_server_error_response_fields"><a class="link" href="#_500_internal_server_error_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2025-08-12 01:36:22 +0900
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
+</body>
+</html>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -521,6 +521,24 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_피드_목록_조회_response_fields">Response fields</a></li>
 </ul>
 </li>
+<li><a href="#_피드_작성">피드 작성</a>
+<ul class="sectlevel3">
+<li><a href="#_피드_작성_http_request">HTTP request</a></li>
+<li><a href="#_피드_작성_request_headers">Request headers</a></li>
+<li><a href="#_피드_작성_request_parts">Request parts</a></li>
+<li><a href="#_피드_작성_http_response">HTTP response</a></li>
+<li><a href="#_피드_작성_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_피드_댓글_목록_조회">피드 댓글 목록 조회</a>
+<ul class="sectlevel3">
+<li><a href="#_피드_댓글_목록_조회_http_request">HTTP request</a></li>
+<li><a href="#_피드_댓글_목록_조회_path_parameters">Path parameters</a></li>
+<li><a href="#_피드_댓글_목록_조회_query_parameters">Query parameters</a></li>
+<li><a href="#_피드_댓글_목록_조회_http_response">HTTP response</a></li>
+<li><a href="#_피드_댓글_목록_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
 </ul>
 </li>
 <li><a href="#board-api">보드 API</a>
@@ -1461,10 +1479,10 @@ Host: api.mykku.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 1472
+Content-Length: 1616
 
 {
-  "message" : "홈 피드 목록 불러오기에 성공했습니다.",
+  "message" : "피드 목록 불러오기에 성공했습니다.",
   "data" : {
     "feeds" : [ {
       "id" : 1,
@@ -1478,7 +1496,15 @@ Content-Length: 1472
       "createdAt" : "2024-01-01T12:00:00",
       "title" : "첫 번째 피드 제목",
       "content" : "첫 번째 피드 내용입니다.",
-      "images" : [ "https://example.com/image1.jpg", "https://example.com/image2.jpg" ],
+      "images" : [ {
+        "url" : "https://example.com/image1.jpg",
+        "width" : 1920,
+        "height" : 1080
+      }, {
+        "url" : "https://example.com/image2.jpg",
+        "width" : 800,
+        "height" : 600
+      } ],
       "tags" : [ "태그1", "태그2" ],
       "likeCount" : 10,
       "isLiked" : true,
@@ -1595,7 +1621,22 @@ Content-Length: 1472
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].images</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">피드 이미지 URL 목록</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 이미지 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].images[].url</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].images[].width</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 가로 크기 (픽셀)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].images[].height</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 세로 크기 (픽셀)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].tags</code></p></td>
@@ -1641,6 +1682,506 @@ Content-Length: 1472
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.feeds[].comment.content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_피드_작성"><a class="link" href="#_피드_작성">피드 작성</a></h3>
+<div class="sect3">
+<h4 id="_피드_작성_http_request"><a class="link" href="#_피드_작성_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/feeds HTTP/1.1
+Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer test-token
+Host: api.mykku.com
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=request; filename=request
+Content-Type: application/json
+
+{
+            "title": "새로운 피드 제목",
+            "content": "피드 내용입니다. 오늘은 날씨가 좋네요.",
+            "boardId": 1,
+            "tags": ["일상", "날씨", "행복"]
+        }
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=images; filename=test-image1.jpg
+Content-Type: image/jpeg
+
+mock image content 1
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=images; filename=test-image2.jpg
+Content-Type: image/jpeg
+
+mock image content 2
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_작성_request_headers"><a class="link" href="#_피드_작성_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_작성_request_parts"><a class="link" href="#_피드_작성_request_parts">Request parts</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Part</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>request</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 생성 요청 정보 (JSON)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">업로드할 이미지 파일들</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_작성_http_response"><a class="link" href="#_피드_작성_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 753
+
+{
+  "message" : "피드가 성공적으로 작성되었습니다.",
+  "data" : {
+    "id" : 1,
+    "title" : "새로운 피드 제목",
+    "content" : "피드 내용입니다. 오늘은 날씨가 좋네요.",
+    "boardId" : 1,
+    "boardTitle" : "자유게시판",
+    "authorId" : "member1",
+    "authorNickname" : "테스트유저",
+    "authorProfileUrl" : "https://example.com/profile.jpg",
+    "images" : [ {
+      "url" : "https://example.com/image1.jpg",
+      "width" : 1920,
+      "height" : 1080
+    }, {
+      "url" : "https://example.com/image2.jpg",
+      "width" : 800,
+      "height" : 600
+    } ],
+    "tags" : [ "일상", "날씨", "행복" ],
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "createdAt" : "2024-01-01T12:00:00"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_작성_response_fields"><a class="link" href="#_피드_작성_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boardTitle</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.authorId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.authorNickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.authorProfileUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 프로필 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.images[].url</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.images[].width</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 가로 크기 (픽셀)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.images[].height</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 세로 크기 (픽셀)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.tags</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">태그 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 일시</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_피드_댓글_목록_조회"><a class="link" href="#_피드_댓글_목록_조회">피드 댓글 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_피드_댓글_목록_조회_http_request"><a class="link" href="#_피드_댓글_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/feeds/1/comments?page=0&amp;size=20 HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Host: api.mykku.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_댓글_목록_조회_path_parameters"><a class="link" href="#_피드_댓글_목록_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/feeds/{feedId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>feedId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">피드 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_댓글_목록_조회_query_parameters"><a class="link" href="#_피드_댓글_목록_조회_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호 (0부터 시작)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 크기 (기본값: 20)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_피드_댓글_목록_조회_http_response"><a class="link" href="#_피드_댓글_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 1440
+
+{
+  "message" : "댓글 목록을 성공적으로 조회했습니다.",
+  "data" : {
+    "comments" : [ {
+      "id" : 1,
+      "content" : "좋은 글이네요!",
+      "author" : {
+        "memberId" : "member1",
+        "nickname" : "댓글작성자1",
+        "profileImage" : "https://example.com/profile1.jpg"
+      },
+      "likeCount" : 5,
+      "isLiked" : false,
+      "replies" : [ {
+        "id" : 2,
+        "content" : "저도 동의합니다!",
+        "author" : {
+          "memberId" : "member2",
+          "nickname" : "대댓글작성자",
+          "profileImage" : "https://example.com/profile2.jpg"
+        },
+        "likeCount" : 2,
+        "isLiked" : false,
+        "createdAt" : "2024-01-01T13:00:00",
+        "updatedAt" : "2024-01-01T13:00:00"
+      } ],
+      "replyCount" : 1,
+      "createdAt" : "2024-01-01T12:00:00",
+      "updatedAt" : "2024-01-01T12:00:00"
+    }, {
+      "id" : 3,
+      "content" : "유익한 정보 감사합니다",
+      "author" : {
+        "memberId" : "member3",
+        "nickname" : "댓글작성자2",
+        "profileImage" : "https://example.com/profile3.jpg"
+      },
+      "likeCount" : 3,
+      "isLiked" : true,
+      "replies" : [ ],
+      "replyCount" : 0,
+      "createdAt" : "2024-01-01T14:00:00",
+      "updatedAt" : "2024-01-01T14:00:00"
+    } ],
+    "totalElements" : 2,
+    "totalPages" : 1,
+    "currentPage" : 0,
+    "pageSize" : 20,
+    "hasNext" : false
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_피드_댓글_목록_조회_response_fields"><a class="link" href="#_피드_댓글_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].author.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].author.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].author.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].isLiked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자의 좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].author.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 작성자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].author.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].author.profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 작성자 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].isLiked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 작성 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replies[].updatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 수정 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].replyCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 작성 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.comments[].updatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 수정 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 댓글 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.currentPage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 크기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 존재 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -3804,7 +4345,7 @@ Content-Length: 92
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-08-12 01:36:22 +0900
+Last updated 2025-08-16 22:36:30 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
@@ -10,19 +10,23 @@ import com.example.mykku.feed.dto.CreateFeedResponse
 import com.example.mykku.feed.dto.FeedImageResponse
 import com.example.mykku.feed.dto.FeedResponse
 import com.example.mykku.feed.dto.FeedsResponse
+import com.example.mykku.feed.dto.FeedCommentsResponse
+import com.example.mykku.feed.dto.FeedCommentResponse
+import com.example.mykku.feed.dto.CommentAuthorResponse
+import com.example.mykku.feed.dto.FeedCommentReplyResponse
 import com.example.mykku.feed.service.FeedService
+import com.example.mykku.feed.service.FeedCommentService
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.restdocs.RestDocumentationContextProvider
@@ -39,6 +43,7 @@ import org.springframework.restdocs.request.RequestDocumentation.parameterWithNa
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.partWithName
 import org.springframework.restdocs.request.RequestDocumentation.requestParts
+import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
@@ -61,13 +66,14 @@ class FeedControllerRestDocsTest {
     private lateinit var feedService: FeedService
     
     @Mock
-    private lateinit var mockObjectMapper: com.fasterxml.jackson.databind.ObjectMapper
-
-    @InjectMocks
+    private lateinit var feedCommentService: FeedCommentService
+    
     private lateinit var feedController: FeedController
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
+        feedController = FeedController(feedService, feedCommentService)
+        
         mockMvc = MockMvcBuilders.standaloneSetup(feedController)
             .setCustomArgumentResolvers(TestMemberArgumentResolver())
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
@@ -230,13 +236,12 @@ class FeedControllerRestDocsTest {
         `when`(feedService.createFeed(any(), any())).thenReturn(response)
 
         // when & then
-        val requestDto = CreateFeedRequestDto(
-            title = "새로운 피드 제목",
-            content = "피드 내용입니다. 오늘은 날씨가 좋네요.",
-            boardId = 1L,
-            tags = listOf("일상", "날씨", "행복")
-        )
-        val requestJson = objectMapper.writeValueAsString(requestDto)
+        val requestJson = """{
+            "title": "새로운 피드 제목",
+            "content": "피드 내용입니다. 오늘은 날씨가 좋네요.",
+            "boardId": 1,
+            "tags": ["일상", "날씨", "행복"]
+        }"""
         
         val mockImageFile1 = MockMultipartFile(
             "images",
@@ -266,11 +271,9 @@ class FeedControllerRestDocsTest {
                 .file(mockImageFile2)
                 .header("Authorization", "Bearer test-token")
         )
+            .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.message").value("피드가 성공적으로 작성되었습니다."))
-            .andExpect(jsonPath("$.data.id").value(1))
-            .andExpect(jsonPath("$.data.title").value("새로운 피드 제목"))
-            .andDo(MockMvcResultHandlers.print())
             .andDo(
                 document(
                     "feed-create",
@@ -299,6 +302,120 @@ class FeedControllerRestDocsTest {
                         fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
                         fieldWithPath("data.commentCount").type(JsonFieldType.NUMBER).description("댓글 수"),
                         fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("작성 일시")
+                    )
+                )
+            )
+    }
+    
+    @Test
+    fun `피드 댓글 목록 조회 API 문서화`() {
+        // given
+        val feedId = 1L
+        val feedCommentsResponse = FeedCommentsResponse(
+            comments = listOf(
+                FeedCommentResponse(
+                    id = 1L,
+                    content = "좋은 글이네요!",
+                    author = CommentAuthorResponse(
+                        memberId = "member1",
+                        nickname = "댓글작성자1",
+                        profileImage = "https://example.com/profile1.jpg"
+                    ),
+                    likeCount = 5,
+                    isLiked = false,
+                    replies = listOf(
+                        FeedCommentReplyResponse(
+                            id = 2L,
+                            content = "저도 동의합니다!",
+                            author = CommentAuthorResponse(
+                                memberId = "member2",
+                                nickname = "대댓글작성자",
+                                profileImage = "https://example.com/profile2.jpg"
+                            ),
+                            likeCount = 2,
+                            isLiked = false,
+                            createdAt = LocalDateTime.of(2024, 1, 1, 13, 0),
+                            updatedAt = LocalDateTime.of(2024, 1, 1, 13, 0)
+                        )
+                    ),
+                    replyCount = 1,
+                    createdAt = LocalDateTime.of(2024, 1, 1, 12, 0),
+                    updatedAt = LocalDateTime.of(2024, 1, 1, 12, 0)
+                ),
+                FeedCommentResponse(
+                    id = 3L,
+                    content = "유익한 정보 감사합니다",
+                    author = CommentAuthorResponse(
+                        memberId = "member3",
+                        nickname = "댓글작성자2",
+                        profileImage = "https://example.com/profile3.jpg"
+                    ),
+                    likeCount = 3,
+                    isLiked = true,
+                    replies = emptyList(),
+                    replyCount = 0,
+                    createdAt = LocalDateTime.of(2024, 1, 1, 14, 0),
+                    updatedAt = LocalDateTime.of(2024, 1, 1, 14, 0)
+                )
+            ),
+            totalElements = 2,
+            totalPages = 1,
+            currentPage = 0,
+            pageSize = 20,
+            hasNext = false
+        )
+        
+        `when`(feedCommentService.getComments(eq(1L), eq(null), any())).thenReturn(feedCommentsResponse)
+        
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/feeds/{feedId}/comments", feedId)
+                .param("page", "0")
+                .param("size", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("댓글 목록을 성공적으로 조회했습니다."))
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document(
+                    "feed-comments-list",
+                    pathParameters(
+                        parameterWithName("feedId").description("피드 ID")
+                    ),
+                    queryParameters(
+                        parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+                        parameterWithName("size").description("페이지 크기 (기본값: 20)").optional()
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.comments").type(JsonFieldType.ARRAY).description("댓글 목록"),
+                        fieldWithPath("data.comments[].id").type(JsonFieldType.NUMBER).description("댓글 ID"),
+                        fieldWithPath("data.comments[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                        fieldWithPath("data.comments[].author.memberId").type(JsonFieldType.STRING).description("작성자 ID"),
+                        fieldWithPath("data.comments[].author.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                        fieldWithPath("data.comments[].author.profileImage").type(JsonFieldType.STRING).description("작성자 프로필 이미지"),
+                        fieldWithPath("data.comments[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
+                        fieldWithPath("data.comments[].isLiked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 좋아요 여부"),
+                        fieldWithPath("data.comments[].replies").type(JsonFieldType.ARRAY).description("대댓글 목록"),
+                        fieldWithPath("data.comments[].replies[].id").type(JsonFieldType.NUMBER).description("대댓글 ID").optional(),
+                        fieldWithPath("data.comments[].replies[].content").type(JsonFieldType.STRING).description("대댓글 내용").optional(),
+                        fieldWithPath("data.comments[].replies[].author.memberId").type(JsonFieldType.STRING).description("대댓글 작성자 ID").optional(),
+                        fieldWithPath("data.comments[].replies[].author.nickname").type(JsonFieldType.STRING).description("대댓글 작성자 닉네임").optional(),
+                        fieldWithPath("data.comments[].replies[].author.profileImage").type(JsonFieldType.STRING).description("대댓글 작성자 프로필 이미지").optional(),
+                        fieldWithPath("data.comments[].replies[].likeCount").type(JsonFieldType.NUMBER).description("대댓글 좋아요 수").optional(),
+                        fieldWithPath("data.comments[].replies[].isLiked").type(JsonFieldType.BOOLEAN).description("대댓글 좋아요 여부").optional(),
+                        fieldWithPath("data.comments[].replies[].createdAt").type(JsonFieldType.STRING).description("대댓글 작성 시간").optional(),
+                        fieldWithPath("data.comments[].replies[].updatedAt").type(JsonFieldType.STRING).description("대댓글 수정 시간").optional(),
+                        fieldWithPath("data.comments[].replyCount").type(JsonFieldType.NUMBER).description("대댓글 수"),
+                        fieldWithPath("data.comments[].createdAt").type(JsonFieldType.STRING).description("댓글 작성 시간"),
+                        fieldWithPath("data.comments[].updatedAt").type(JsonFieldType.STRING).description("댓글 수정 시간"),
+                        fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER).description("전체 댓글 수"),
+                        fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                        fieldWithPath("data.currentPage").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
                     )
                 )
             )

--- a/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
@@ -16,6 +16,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.springframework.data.domain.Pageable
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.mock.web.MockMultipartFile
@@ -369,7 +371,7 @@ class FeedControllerRestDocsTest {
             hasNext = false
         )
 
-        `when`(feedCommentService.getComments(eq(1L), eq(null), any())).thenReturn(feedCommentsResponse)
+        `when`(feedCommentService.getComments(eq(1L), eq("member123"), any<Pageable>())).thenReturn(feedCommentsResponse)
 
         // when & then
         mockMvc.perform(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: mykku
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=MySQL
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,7 +10,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: mykku
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  sql:
+    init:
+      mode: never
+
+jwt:
+  secret: test-secret-key-should-be-very-long-and-secure-at-least-32-characters-long
+  expiration: 86400000
+
+aws:
+  s3:
+    enabled: false
+    access-key: test-access-key
+    secret-key: test-secret-key
+    region: ap-northeast-2
+    bucket-name: test-bucket

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS feed_image (
 -- Create Tag table
 CREATE TABLE IF NOT EXISTS tag (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(20) NOT NULL,
+    title VARCHAR(20) NOT NULL UNIQUE,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,4 +1,4 @@
--- MySQL Schema for MYKKU Application
+-- H2 Test Database Schema for MYKKU Application
 
 -- Create Member table
 CREATE TABLE IF NOT EXISTS member (
@@ -6,13 +6,13 @@ CREATE TABLE IF NOT EXISTS member (
     nickname VARCHAR(10) NOT NULL,
     role VARCHAR(255) NOT NULL,
     profile_image VARCHAR(255) NOT NULL,
-    provider ENUM('GOOGLE', 'KAKAO', 'NAVER', 'APPLE') NOT NULL,
+    provider VARCHAR(20) NOT NULL,
     social_id VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL,
     follower_count INT DEFAULT 0,
     following_count INT DEFAULT 0,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 -- Create Board table
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS board (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(16) NOT NULL,
     logo VARCHAR(255) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 -- Create Feed table
@@ -33,8 +33,8 @@ CREATE TABLE IF NOT EXISTS feed (
     comment_count INT DEFAULT 0,
     board_id BIGINT NOT NULL,
     member_id VARCHAR(255) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (board_id) REFERENCES board(id),
     FOREIGN KEY (member_id) REFERENCES member(id)
 );
@@ -53,8 +53,8 @@ CREATE TABLE IF NOT EXISTS feed_image (
 CREATE TABLE IF NOT EXISTS tag (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(20) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 -- Create FeedTag table (Many-to-Many relationship between Feed and Tag)
@@ -62,8 +62,8 @@ CREATE TABLE IF NOT EXISTS feed_tag (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     feed_id BIGINT NOT NULL,
     tag_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE,
     FOREIGN KEY (tag_id) REFERENCES tag(id) ON DELETE CASCADE
 );
@@ -76,8 +76,8 @@ CREATE TABLE IF NOT EXISTS feed_comment (
     feed_id BIGINT NOT NULL,
     parent_comment_id BIGINT NULL,
     member_id VARCHAR(255) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE,
     FOREIGN KEY (parent_comment_id) REFERENCES feed_comment(id),
     FOREIGN KEY (member_id) REFERENCES member(id)
@@ -89,8 +89,8 @@ CREATE TABLE IF NOT EXISTS daily_message (
     title VARCHAR(255) NOT NULL,
     content VARCHAR(42) NOT NULL,
     date DATE NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 -- Create DailyMessageComment table
@@ -101,8 +101,8 @@ CREATE TABLE IF NOT EXISTS daily_message_comment (
     daily_message_id BIGINT NOT NULL,
     parent_comment_id BIGINT NULL,
     member_id VARCHAR(255) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (daily_message_id) REFERENCES daily_message(id) ON DELETE CASCADE,
     FOREIGN KEY (parent_comment_id) REFERENCES daily_message_comment(id),
     FOREIGN KEY (member_id) REFERENCES member(id)
@@ -114,8 +114,7 @@ CREATE TABLE IF NOT EXISTS follow (
     follower_id VARCHAR(255) NOT NULL,
     following_id VARCHAR(255) NOT NULL,
     FOREIGN KEY (follower_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (following_id) REFERENCES member(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_follow (follower_id, following_id)
+    FOREIGN KEY (following_id) REFERENCES member(id) ON DELETE CASCADE
 );
 
 -- Create SaveFeed table
@@ -123,11 +122,10 @@ CREATE TABLE IF NOT EXISTS save_feed (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
     feed_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_save_feed (member_id, feed_id)
+    FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE
 );
 
 -- Create SaveDailyMessage table
@@ -135,11 +133,10 @@ CREATE TABLE IF NOT EXISTS save_daily_message (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
     daily_message_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (daily_message_id) REFERENCES daily_message(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_save_daily_message (member_id, daily_message_id)
+    FOREIGN KEY (daily_message_id) REFERENCES daily_message(id) ON DELETE CASCADE
 );
 
 -- Create LikeFeed table
@@ -147,11 +144,10 @@ CREATE TABLE IF NOT EXISTS like_feed (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
     feed_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_like_feed (member_id, feed_id)
+    FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE
 );
 
 -- Create LikeFeedComment table
@@ -159,11 +155,10 @@ CREATE TABLE IF NOT EXISTS like_feed_comment (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
     feed_comment_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (feed_comment_id) REFERENCES feed_comment(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_like_feed_comment (member_id, feed_comment_id)
+    FOREIGN KEY (feed_comment_id) REFERENCES feed_comment(id) ON DELETE CASCADE
 );
 
 -- Create LikeDailyMessageComment table
@@ -171,11 +166,10 @@ CREATE TABLE IF NOT EXISTS like_daily_message_comment (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
     daily_message_comment_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (daily_message_comment_id) REFERENCES daily_message_comment(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_like_daily_message_comment (member_id, daily_message_comment_id)
+    FOREIGN KEY (daily_message_comment_id) REFERENCES daily_message_comment(id) ON DELETE CASCADE
 );
 
 -- Create LikeBoard table
@@ -184,17 +178,16 @@ CREATE TABLE IF NOT EXISTS like_board (
     member_id VARCHAR(255) NOT NULL,
     board_id BIGINT NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-    FOREIGN KEY (board_id) REFERENCES board(id) ON DELETE CASCADE,
-    UNIQUE KEY unique_like_board (member_id, board_id)
+    FOREIGN KEY (board_id) REFERENCES board(id) ON DELETE CASCADE
 );
 
 -- Create Event table
 CREATE TABLE IF NOT EXISTS event (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
-    expired_at DATETIME(6) NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    expired_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 -- Create EventImage table
@@ -213,18 +206,18 @@ CREATE TABLE IF NOT EXISTS contest_winner (
     acceptance_speech VARCHAR(255) NOT NULL,
     image VARCHAR(255) NOT NULL,
     event_id BIGINT NOT NULL,
-    created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE
 );
 
 -- Create indexes for better performance
-CREATE INDEX idx_feed_board_id ON feed(board_id);
-CREATE INDEX idx_feed_member_id ON feed(member_id);
-CREATE INDEX idx_feed_comment_feed_id ON feed_comment(feed_id);
-CREATE INDEX idx_feed_comment_member_id ON feed_comment(member_id);
-CREATE INDEX idx_daily_message_comment_daily_message_id ON daily_message_comment(daily_message_id);
-CREATE INDEX idx_daily_message_comment_member_id ON daily_message_comment(member_id);
-CREATE INDEX idx_follow_follower_id ON follow(follower_id);
-CREATE INDEX idx_follow_following_id ON follow(following_id);
-CREATE INDEX idx_daily_message_date ON daily_message(date);
+CREATE INDEX IF NOT EXISTS idx_feed_board_id ON feed(board_id);
+CREATE INDEX IF NOT EXISTS idx_feed_member_id ON feed(member_id);
+CREATE INDEX IF NOT EXISTS idx_feed_comment_feed_id ON feed_comment(feed_id);
+CREATE INDEX IF NOT EXISTS idx_feed_comment_member_id ON feed_comment(member_id);
+CREATE INDEX IF NOT EXISTS idx_daily_message_comment_daily_message_id ON daily_message_comment(daily_message_id);
+CREATE INDEX IF NOT EXISTS idx_daily_message_comment_member_id ON daily_message_comment(member_id);
+CREATE INDEX IF NOT EXISTS idx_follow_follower_id ON follow(follower_id);
+CREATE INDEX IF NOT EXISTS idx_follow_following_id ON follow(following_id);
+CREATE INDEX IF NOT EXISTS idx_daily_message_date ON daily_message(date);


### PR DESCRIPTION
# 🚩 연관 이슈

closed #25 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 피드 작성 API 추가: 멀티파트 이미지 업로드(최대 10장), 태그(최대 7개) 지원 및 이미지에 가로/세로 정보 포함.
  - 피드 댓글 목록 조회 API 추가: 댓글·대댓글 페이징 지원.
  - AWS S3 기반 이미지 업로드 서비스 통합(환경 설정으로 활성화).

- **변경 사항**
  - 응답 이미지 구조를 객체(url, width, height)로 변경.
  - 이미지 업로드 유효성(확장자, 최대 10MB) 및 관련 클라이언트 오류 코드 추가.
  - 태그명에 유니크 제약 및 API 기본 경로 정리(/api/v1).

- **문서**
  - 피드 작성·댓글 목록 API 문서·예제 추가/보강.

- **테스트**
  - REST Docs 테스트 및 테스트용 설정/스키마 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->