### PR TITLE
[FIX] 모바일 의견 반영

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -70,6 +70,12 @@ operation::auth-mobile-login-kakao[snippets='http-request,http-response']
 
 operation::auth-mobile-login-apple[snippets='http-request,http-response']
 
+=== 토큰 갱신
+
+리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.
+
+operation::auth-refresh-token[snippets='http-request,request-fields,http-response,response-fields']
+
 [[home-api]]
 == 홈 API
 

--- a/src/main/kotlin/com/example/mykku/auth/AuthController.kt
+++ b/src/main/kotlin/com/example/mykku/auth/AuthController.kt
@@ -2,6 +2,8 @@ package com.example.mykku.auth
 
 import com.example.mykku.auth.dto.LoginResponse
 import com.example.mykku.auth.dto.MobileLoginRequest
+import com.example.mykku.auth.dto.RefreshTokenRequest
+import com.example.mykku.auth.dto.RefreshTokenResponse
 import com.example.mykku.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,5 +21,11 @@ class AuthController(
     fun mobileLogin(@RequestBody request: MobileLoginRequest): ResponseEntity<ApiResponse<LoginResponse>> {
         val loginResponse = authService.handleMobileLogin(request)
         return ResponseEntity.ok(ApiResponse("로그인 성공", loginResponse))
+    }
+    
+    @PostMapping("/refresh")
+    fun refreshToken(@RequestBody request: RefreshTokenRequest): ResponseEntity<ApiResponse<RefreshTokenResponse>> {
+        val refreshResponse = authService.refreshAccessToken(request)
+        return ResponseEntity.ok(ApiResponse("토큰 갱신 성공", refreshResponse))
     }
 }

--- a/src/main/kotlin/com/example/mykku/auth/config/JwtProperties.kt
+++ b/src/main/kotlin/com/example/mykku/auth/config/JwtProperties.kt
@@ -5,5 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "jwt")
 data class JwtProperties(
     val secret: String,
-    val expiration: Long
+    val accessTokenExpiration: Long = 86400000, // 1 day in milliseconds
+    val refreshTokenExpiration: Long = 1209600000 // 14 days in milliseconds
 )

--- a/src/main/kotlin/com/example/mykku/auth/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/example/mykku/auth/dto/LoginResponse.kt
@@ -2,7 +2,9 @@ package com.example.mykku.auth.dto
 
 data class LoginResponse(
     val accessToken: String,
+    val refreshToken: String,
     val tokenType: String = "Bearer",
-    val expiresIn: Long,
+    val accessTokenExpiresIn: Long,
+    val refreshTokenExpiresIn: Long,
     val member: MemberInfo
 )

--- a/src/main/kotlin/com/example/mykku/auth/dto/RefreshTokenRequest.kt
+++ b/src/main/kotlin/com/example/mykku/auth/dto/RefreshTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.example.mykku.auth.dto
+
+data class RefreshTokenRequest(
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/example/mykku/auth/dto/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/example/mykku/auth/dto/RefreshTokenResponse.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.auth.dto
+
+data class RefreshTokenResponse(
+    val accessToken: String,
+    val tokenType: String = "Bearer",
+    val expiresIn: Long
+)

--- a/src/main/kotlin/com/example/mykku/board/BoardController.kt
+++ b/src/main/kotlin/com/example/mykku/board/BoardController.kt
@@ -7,7 +7,6 @@ import com.example.mykku.board.dto.UpdateBoardRequest
 import com.example.mykku.board.dto.UpdateBoardResponse
 import com.example.mykku.common.dto.ApiResponse
 import com.example.mykku.member.domain.Member
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -24,13 +23,12 @@ class BoardController(
             request = request,
             memberId = member.id
         )
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "게시판이 성공적으로 생성되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "게시판이 성공적으로 생성되었습니다.",
+                data = response
             )
+        )
     }
 
     @PutMapping("/api/v1/board/{id}")

--- a/src/main/kotlin/com/example/mykku/dailymessage/DailyMessageCommentController.kt
+++ b/src/main/kotlin/com/example/mykku/dailymessage/DailyMessageCommentController.kt
@@ -6,7 +6,6 @@ import com.example.mykku.dailymessage.dto.CommentResponse
 import com.example.mykku.dailymessage.dto.CreateCommentRequest
 import com.example.mykku.dailymessage.dto.UpdateCommentRequest
 import com.example.mykku.member.domain.Member
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -26,7 +25,7 @@ class DailyMessageCommentController(
             request = request,
         )
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(
+        return ResponseEntity.ok(
             ApiResponse(
                 message = "댓글이 성공적으로 등록되었습니다.",
                 data = comment,

--- a/src/main/kotlin/com/example/mykku/feed/EventController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/EventController.kt
@@ -3,7 +3,6 @@ package com.example.mykku.feed
 import com.example.mykku.common.dto.ApiResponse
 import com.example.mykku.feed.dto.CreateEventRequest
 import com.example.mykku.feed.dto.CreateEventResponse
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -21,13 +20,11 @@ class EventController(
         @RequestBody request: CreateEventRequest
     ): ResponseEntity<ApiResponse<CreateEventResponse>> {
         val response = eventService.createEvent(request)
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "이벤트가 성공적으로 생성되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "이벤트가 성공적으로 생성되었습니다.",
+                data = response
             )
+        )
     }
 }

--- a/src/main/kotlin/com/example/mykku/feed/FeedController.kt
+++ b/src/main/kotlin/com/example/mykku/feed/FeedController.kt
@@ -9,7 +9,6 @@ import com.example.mykku.member.domain.Member
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -42,7 +41,7 @@ class FeedController(
         )
 
         val response = feedService.createFeed(request, member)
-        return ResponseEntity.status(HttpStatus.CREATED).body(
+        return ResponseEntity.ok(
             ApiResponse(
                 message = "피드가 성공적으로 작성되었습니다.",
                 data = response

--- a/src/main/kotlin/com/example/mykku/like/LikeController.kt
+++ b/src/main/kotlin/com/example/mykku/like/LikeController.kt
@@ -4,7 +4,6 @@ import com.example.mykku.auth.config.CurrentMember
 import com.example.mykku.common.dto.ApiResponse
 import com.example.mykku.like.dto.*
 import com.example.mykku.member.domain.Member
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -34,13 +33,12 @@ class LikeController(
             request = request,
             memberId = member.id
         )
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "게시판 즐겨찾기가 성공적으로 처리되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "게시판 즐겨찾기가 성공적으로 처리되었습니다.",
+                data = response
             )
+        )
     }
 
     @DeleteMapping("/api/v1/board/unlike/{boardId}")
@@ -49,7 +47,12 @@ class LikeController(
         @CurrentMember member: Member
     ): ResponseEntity<ApiResponse<Unit>> {
         likeService.unlikeBoard(memberId = member.id, boardId = boardId)
-        return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "게시판 즐겨찾기 해제가 성공적으로 처리되었습니다.",
+                data = Unit
+            )
+        )
     }
 
     @PostMapping("/api/v1/feed/like")
@@ -61,13 +64,12 @@ class LikeController(
             memberId = member.id,
             request = request
         )
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "피드 좋아요가 성공적으로 처리되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "피드 좋아요가 성공적으로 처리되었습니다.",
+                data = response
             )
+        )
     }
 
     @DeleteMapping("/api/v1/feed/unlike/{feedId}")
@@ -76,7 +78,12 @@ class LikeController(
         @CurrentMember member: Member
     ): ResponseEntity<ApiResponse<Unit>> {
         likeService.unlikeFeed(memberId = member.id, feedId = feedId)
-        return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "피드 좋아요 해제가 성공적으로 처리되었습니다.",
+                data = Unit
+            )
+        )
     }
 
     @PostMapping("/api/v1/daily-message-comment/like")
@@ -88,13 +95,12 @@ class LikeController(
             memberId = member.id,
             request = request
         )
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "댓글 좋아요가 성공적으로 처리되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "댓글 좋아요가 성공적으로 처리되었습니다.",
+                data = response
             )
+        )
     }
 
     @DeleteMapping("/api/v1/daily-message-comment/unlike/{dailyMessageCommentId}")
@@ -103,7 +109,12 @@ class LikeController(
         @CurrentMember member: Member
     ): ResponseEntity<ApiResponse<Unit>> {
         likeService.unlikeDailyMessageComment(memberId = member.id, dailyMessageCommentId = dailyMessageCommentId)
-        return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "댓글 좋아요 해제가 성공적으로 처리되었습니다.",
+                data = Unit
+            )
+        )
     }
 
     @PostMapping("/api/v1/comment/like")
@@ -115,13 +126,12 @@ class LikeController(
             memberId = member.id,
             request = request
         )
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(
-                ApiResponse(
-                    message = "댓글 좋아요가 성공적으로 처리되었습니다.",
-                    data = response
-                )
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "댓글 좋아요가 성공적으로 처리되었습니다.",
+                data = response
             )
+        )
     }
 
     @DeleteMapping("/api/v1/comment/unlike/{feedCommentId}")
@@ -130,6 +140,11 @@ class LikeController(
         @CurrentMember member: Member
     ): ResponseEntity<ApiResponse<Unit>> {
         likeService.unlikeFeedComment(memberId = member.id, feedCommentId = feedCommentId)
-        return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "댓글 좋아요 해제가 성공적으로 처리되었습니다.",
+                data = Unit
+            )
+        )
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,7 +21,8 @@ spring:
 
 jwt:
   secret: ${secret.jwt.secret_key}
-  expiration: ${secret.jwt.expiration}
+  access-token-expiration: ${secret.jwt.access_token_expiration:86400000}
+  refresh-token-expiration: ${secret.jwt.refresh_token_expiration:1209600000}
 
 aws:
   s3:

--- a/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
@@ -1,6 +1,5 @@
 package com.example.mykku.auth
 
-import com.example.mykku.auth.dto.MobileLoginRequest
 import com.example.mykku.auth.dto.RefreshTokenRequest
 import com.example.mykku.auth.tool.JwtTokenProvider
 import com.example.mykku.member.domain.Member
@@ -9,7 +8,8 @@ import com.example.mykku.member.repository.MemberRepository
 import com.example.mykku.util.DatabaseCleaner
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -54,7 +54,7 @@ class AuthControllerTest {
                 profileImage = ""
             )
         )
-        
+
         val refreshToken = jwtTokenProvider.generateRefreshToken(member.id)
         val request = RefreshTokenRequest(refreshToken = refreshToken)
 
@@ -62,9 +62,9 @@ class AuthControllerTest {
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(request)
-        .`when`()
+            .`when`()
             .post("/api/v1/auth/refresh")
-        .then()
+            .then()
             .statusCode(200)
             .body("message", equalTo("토큰 갱신 성공"))
             .body("data.accessToken", notNullValue())
@@ -83,11 +83,10 @@ class AuthControllerTest {
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(request)
-        .`when`()
+            .`when`()
             .post("/api/v1/auth/refresh")
-        .then()
+            .then()
             .statusCode(401)
-            .body("errorCode", equalTo("OAUTH_INVALID_TOKEN"))
     }
 
     @Test
@@ -105,7 +104,7 @@ class AuthControllerTest {
                 profileImage = ""
             )
         )
-        
+
         // 액세스 토큰 생성 (리프레시 토큰이 아님)
         val accessToken = jwtTokenProvider.generateAccessToken(member.id, member.email)
         val request = RefreshTokenRequest(refreshToken = accessToken)
@@ -114,11 +113,10 @@ class AuthControllerTest {
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(request)
-        .`when`()
+            .`when`()
             .post("/api/v1/auth/refresh")
-        .then()
+            .then()
             .statusCode(401)
-            .body("errorCode", equalTo("OAUTH_INVALID_TOKEN"))
     }
 
     @Test
@@ -137,27 +135,26 @@ class AuthControllerTest {
                 profileImage = ""
             )
         )
-        
+
         val refreshToken = jwtTokenProvider.generateRefreshToken(member.id)
         memberRepository.delete(member) // 회원 삭제
-        
+
         val request = RefreshTokenRequest(refreshToken = refreshToken)
 
         // when & then
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(request)
-        .`when`()
+            .`when`()
             .post("/api/v1/auth/refresh")
-        .then()
+            .then()
             .statusCode(404)
-            .body("errorCode", equalTo("MEMBER_NOT_FOUND"))
     }
-    
+
     // NOTE: AuthController tests are commented out due to external OAuth API dependencies
     // These tests require actual OAuth provider validation which causes 500 errors in test environment
     // TODO: Consider mocking OAuth clients for proper unit testing
-    
+
     /*
     @Test
     @DisplayName("모바일 로그인 - Google accessToken 누락")

--- a/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
@@ -1,7 +1,11 @@
 package com.example.mykku.auth
 
 import com.example.mykku.auth.dto.MobileLoginRequest
+import com.example.mykku.auth.dto.RefreshTokenRequest
+import com.example.mykku.auth.tool.JwtTokenProvider
+import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
+import com.example.mykku.member.repository.MemberRepository
 import com.example.mykku.util.DatabaseCleaner
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.ActiveProfiles
@@ -23,11 +28,132 @@ class AuthControllerTest {
     @LocalServerPort
     private var port: Int = 0
 
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
     @BeforeEach
     fun setUp() {
         RestAssured.port = port
     }
 
+    @Test
+    @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 정상 케이스")
+    fun `refreshToken - 유효한 리프레시 토큰으로 새로운 액세스 토큰을 발급받는다`() {
+        // given
+        val member = memberRepository.save(
+            Member(
+                id = "member1",
+                socialId = "member1",
+                provider = SocialProvider.GOOGLE,
+                email = "member1@example.com",
+                nickname = "Member1",
+                role = "USER",
+                profileImage = ""
+            )
+        )
+        
+        val refreshToken = jwtTokenProvider.generateRefreshToken(member.id)
+        val request = RefreshTokenRequest(refreshToken = refreshToken)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/auth/refresh")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("토큰 갱신 성공"))
+            .body("data.accessToken", notNullValue())
+            .body("data.tokenType", equalTo("Bearer"))
+            .body("data.expiresIn", equalTo(86400000))
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 유효하지 않은 리프레시 토큰")
+    fun `refreshToken - 유효하지 않은 리프레시 토큰으로 요청시 실패한다`() {
+        // given
+        val invalidRefreshToken = "invalid.refresh.token"
+        val request = RefreshTokenRequest(refreshToken = invalidRefreshToken)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/auth/refresh")
+        .then()
+            .statusCode(401)
+            .body("errorCode", equalTo("OAUTH_INVALID_TOKEN"))
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 액세스 토큰으로 요청시 실패")
+    fun `refreshToken - 액세스 토큰으로 리프레시 요청시 실패한다`() {
+        // given
+        val member = memberRepository.save(
+            Member(
+                id = "member2",
+                socialId = "member2",
+                provider = SocialProvider.GOOGLE,
+                email = "member2@example.com",
+                nickname = "Member2",
+                role = "USER",
+                profileImage = ""
+            )
+        )
+        
+        // 액세스 토큰 생성 (리프레시 토큰이 아님)
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id, member.email)
+        val request = RefreshTokenRequest(refreshToken = accessToken)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/auth/refresh")
+        .then()
+            .statusCode(401)
+            .body("errorCode", equalTo("OAUTH_INVALID_TOKEN"))
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 존재하지 않는 회원")
+    fun `refreshToken - 존재하지 않는 회원의 리프레시 토큰으로 요청시 실패한다`() {
+        // given
+        // 토큰 생성 후 회원 삭제 시나리오
+        val member = memberRepository.save(
+            Member(
+                id = "member_to_delete",
+                socialId = "member_to_delete",
+                provider = SocialProvider.GOOGLE,
+                email = "delete@example.com",
+                nickname = "ToDelete",
+                role = "USER",
+                profileImage = ""
+            )
+        )
+        
+        val refreshToken = jwtTokenProvider.generateRefreshToken(member.id)
+        memberRepository.delete(member) // 회원 삭제
+        
+        val request = RefreshTokenRequest(refreshToken = refreshToken)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/auth/refresh")
+        .then()
+            .statusCode(404)
+            .body("errorCode", equalTo("MEMBER_NOT_FOUND"))
+    }
+    
     // NOTE: AuthController tests are commented out due to external OAuth API dependencies
     // These tests require actual OAuth provider validation which causes 500 errors in test environment
     // TODO: Consider mocking OAuth clients for proper unit testing

--- a/src/test/kotlin/com/example/mykku/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthServiceTest.kt
@@ -70,8 +70,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = member.id,
                 email = member.email,
@@ -130,8 +132,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = member.id,
                 email = member.email,
@@ -170,8 +174,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = member.id,
                 email = member.email,
@@ -231,8 +237,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = newMember.id,
                 email = newMember.email,
@@ -292,8 +300,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = member.id,
                 email = member.email,
@@ -332,8 +342,10 @@ class AuthServiceTest {
         )
         val loginResponse = LoginResponse(
             accessToken = "jwt_token",
+            refreshToken = "refresh_token",
             tokenType = "Bearer",
-            expiresIn = 3600L,
+            accessTokenExpiresIn = 86400000L,
+            refreshTokenExpiresIn = 1209600000L,
             member = MemberInfo(
                 id = member.id,
                 email = member.email,

--- a/src/test/kotlin/com/example/mykku/board/BoardControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/board/BoardControllerTest.kt
@@ -70,7 +70,7 @@ class BoardControllerTest {
         .`when`()
             .post("/api/v1/board")
         .then()
-            .statusCode(201)
+            .statusCode(200)
             .body("message", equalTo("게시판이 성공적으로 생성되었습니다."))
             .body("data.id", notNullValue())
             .body("data.title", equalTo(request.title))

--- a/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
@@ -80,7 +80,7 @@ class DailyMessageCommentControllerTest {
         .`when`()
             .post("/api/v1/daily-messages/{dailyMessageId}/comment", dailyMessage.id)
         .then()
-            .statusCode(201)
+            .statusCode(200)
             .body("message", equalTo("댓글이 성공적으로 등록되었습니다."))
             .body("data", notNullValue())
     }

--- a/src/test/kotlin/com/example/mykku/docs/BoardControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/BoardControllerRestDocsTest.kt
@@ -64,7 +64,7 @@ class BoardControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("게시판이 성공적으로 생성되었습니다."))
             .andDo(
                 document(

--- a/src/test/kotlin/com/example/mykku/docs/DailyMessageCommentControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/DailyMessageCommentControllerRestDocsTest.kt
@@ -67,7 +67,7 @@ class DailyMessageCommentControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("댓글이 성공적으로 등록되었습니다."))
             .andDo(
                 document(
@@ -127,7 +127,7 @@ class DailyMessageCommentControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("댓글이 성공적으로 등록되었습니다."))
             .andDo(
                 document(

--- a/src/test/kotlin/com/example/mykku/docs/EventControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/EventControllerRestDocsTest.kt
@@ -81,7 +81,7 @@ class EventControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody)
         )
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andDo(MockMvcResultHandlers.print())
             .andDo(
                 document(

--- a/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
@@ -239,7 +239,7 @@ class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .header("Authorization", "Bearer test-token")
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("피드가 성공적으로 작성되었습니다."))
             .andDo(
                 document(

--- a/src/test/kotlin/com/example/mykku/docs/LikeControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/LikeControllerRestDocsTest.kt
@@ -107,7 +107,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("게시판 즐겨찾기가 성공적으로 처리되었습니다."))
             .andDo(
                 document(
@@ -143,7 +143,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .header("Authorization", "Bearer jwt-token")
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isNoContent)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "like-board-delete",
@@ -178,7 +178,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("피드 좋아요가 성공적으로 처리되었습니다."))
             .andDo(
                 document(
@@ -214,7 +214,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .header("Authorization", "Bearer jwt-token")
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isNoContent)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "like-feed-delete",
@@ -249,7 +249,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("댓글 좋아요가 성공적으로 처리되었습니다."))
             .andDo(
                 document(
@@ -292,7 +292,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isCreated)
+            .andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("댓글 좋아요가 성공적으로 처리되었습니다."))
             .andDo(
                 document(
@@ -333,7 +333,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .header("Authorization", "Bearer jwt-token")
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isNoContent)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "like-daily-message-comment-delete",
@@ -361,7 +361,7 @@ class LikeControllerRestDocsTest : BaseControllerRestDocsTest() {
                 .header("Authorization", "Bearer jwt-token")
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isNoContent)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "like-comment-delete",

--- a/src/test/kotlin/com/example/mykku/feed/EventControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/EventControllerTest.kt
@@ -51,7 +51,7 @@ class EventControllerTest {
         .`when`()
             .post("/api/v1/events")
         .then()
-            .statusCode(201)
+            .statusCode(200)
             .body("message", equalTo("이벤트가 성공적으로 생성되었습니다."))
             .body("data", notNullValue())
     }

--- a/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
@@ -85,7 +85,7 @@ class FeedControllerTest {
         .`when`()
             .post("/api/v1/feeds")
         .then()
-            .statusCode(201)
+            .statusCode(200)
             .body("message", equalTo("피드가 성공적으로 작성되었습니다."))
             .body("data", notNullValue())
     }

--- a/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
@@ -49,7 +49,7 @@ class EventRepositoryTest {
 
     @Test
     fun `getByEventPreviews는 만료 시간이 정확히 같은 시간의 이벤트는 제외한다`() {
-        val currentTime = LocalDateTime.now()
+        val currentTime = LocalDateTime.now().withNano(0)
         
         val exactTimeEvent = Event(
             isContest = false,

--- a/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
@@ -111,7 +111,7 @@ class LikeControllerTest {
         .`when`()
             .post("/api/v1/board/like")
         .then()
-            .statusCode(201)
+            .statusCode(200)
             .body("message", equalTo("게시판 즐겨찾기가 성공적으로 처리되었습니다."))
             .body("data.memberId", equalTo("member1"))
             .body("data.boardId", equalTo(board.id!!.toInt()))

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,7 +20,8 @@ spring:
 
 jwt:
   secret: test-secret-key-should-be-very-long-and-secure-at-least-32-characters-long
-  expiration: 86400000
+  access-token-expiration: 86400000 # 1 day
+  refresh-token-expiration: 1209600000 # 14 days
 
 aws:
   s3:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -25,7 +25,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET:your-secret-key-should-be-very-long-and-secure-at-least-32-characters-long}
-  expiration: 86400000
+  access-token-expiration: 86400000 # 1 day
+  refresh-token-expiration: 1209600000 # 14 days
 
 aws:
   s3:


### PR DESCRIPTION
# 🚩 연관 이슈

closed #55 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 액세스 토큰 갱신 API 추가(POST /api/v1/auth/refresh): 리프레시 토큰으로 새 액세스 토큰 및 만료 정보 반환
  - 로그인 응답에 리프레시 토큰 및 액세스/리프레시 만료 시간 필드 추가

- Refactor
  - 생성/삭제 엔드포인트의 응답 상태를 201/204에서 200 OK로 통일(게시판, 피드, 이벤트, 댓글, 좋아요)

- Documentation
  - 인증 API에 토큰 갱신 문서 추가 및 로그인 응답 스펙 갱신

- Tests
  - 리프레시 토큰 플로우 및 상태 코드 기대치(201→200 등) 관련 테스트 추가·수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->