### PR TITLE
[FEAT] 덕질노트 기능

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,9 +181,86 @@ src/main/kotlin/com/example/mykku/
     - [ ] 테스트 커버리지 확인
     - [ ] RestDocs 문서화
 
+## Testing Requirements
+
+새로운 기능을 추가할 때는 **반드시** 다음 5가지 계층의 테스트를 모두 작성해야 합니다:
+
+### 1. RestDocsTest
+- **위치**: `src/test/kotlin/com/example/mykku/docs/[Domain]ControllerRestDocsTest.kt`
+- **상속**: `BaseControllerRestDocsTest`를 상속
+- **목적**: API 문서 자동 생성
+- **필수 요소**:
+  - `@Mock` Service 주입
+  - `@InjectMocks` Controller 주입
+  - MockMvcBuilders.standaloneSetup() 사용
+  - document() 메서드로 API 문서화
+  - 요청/응답 필드 상세 설명
+
+### 2. ControllerTest
+- **위치**: `src/test/kotlin/com/example/mykku/[domain]/[Domain]ControllerTest.kt`
+- **어노테이션**: `@WebMvcTest([Domain]Controller::class)`
+- **목적**: Controller 단위 테스트
+- **필수 요소**:
+  - `@MockBean` Service 주입
+  - HTTP 요청/응답 검증
+  - 에러 케이스 테스트
+
+### 3. ServiceTest
+- **위치**: `src/test/kotlin/com/example/mykku/[domain]/[Domain]ServiceTest.kt`
+- **어노테이션**: `@ExtendWith(MockitoExtension::class)`
+- **목적**: 비즈니스 로직 테스트
+- **필수 요소**:
+  - `@Mock` Tool 계층 주입
+  - `@InjectMocks` Service 주입
+  - 정상 케이스와 예외 케이스 테스트
+
+### 4. ToolTest
+- **위치**: `src/test/kotlin/com/example/mykku/[domain]/tool/[Tool]Test.kt`
+- **어노테이션**: `@ExtendWith(MockitoExtension::class)`
+- **목적**: 데이터 접근 로직 테스트
+- **필수 요소**:
+  - `@Mock` Repository 주입
+  - `@InjectMocks` Tool (Reader/Writer) 주입
+  - 데이터 변환 로직 검증
+
+### 5. RepositoryTest
+- **위치**: `src/test/kotlin/com/example/mykku/[domain]/repository/[Domain]RepositoryTest.kt`
+- **어노테이션**: `@DataJpaTest`
+- **목적**: 실제 데이터베이스 쿼리 테스트
+- **필수 요소**:
+  - TestEntityManager 사용
+  - 실제 JPA 쿼리 동작 검증
+  - 커스텀 쿼리 메서드 테스트
+
+### API 문서화 (RestDocs)
+
+RestDocsTest 작성 후 반드시:
+1. `src/docs/asciidoc/index.adoc` 파일에 API 섹션 추가
+2. operation 스니펫 참조 추가
+3. 다음 형식 준수:
+```asciidoc
+[[domain-api]]
+== 도메인 API
+
+=== API 이름
+
+API 설명
+
+operation::operation-name[snippets='http-request,request-fields,http-response,response-fields']
+```
+
+### 테스트 작성 체크리스트
+- [ ] RestDocsTest 작성 및 API 문서 생성
+- [ ] ControllerTest로 엔드포인트 검증
+- [ ] ServiceTest로 비즈니스 로직 검증
+- [ ] ToolTest로 데이터 접근 로직 검증
+- [ ] RepositoryTest로 실제 쿼리 동작 확인
+- [ ] index.adoc에 API 문서 섹션 추가
+
 ## Important Notes
 
 - **절대 Service에서 Repository를 직접 주입하지 마세요**
 - **Controller에서는 오직 Service만 사용하세요**
 - **복잡한 쿼리는 Tool 계층에 캡슐화하세요**
 - **페이지네이션은 항상 적용을 고려하세요**
+- **모든 기능은 5계층 테스트를 완전히 구현하세요**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,40 @@ MyKKU는 덕질 커뮤니티 플랫폼의 백엔드 서비스입니다.
 
 ## Architecture and Dependency Rules
 
+### JPA Entity Relationship Rules
+
+#### OneToMany 관계 사용 금지
+- **절대 OneToMany 관계를 사용하지 마세요**
+- 부모 엔티티에서 자식 컬렉션을 관리하는 것은 성능 및 메모리 문제를 야기할 수 있습니다
+- 대신 다음 패턴을 사용하세요:
+  - 자식 엔티티에서 ManyToOne 관계만 사용
+  - 부모 엔티티의 자식들이 필요한 경우, 별도의 Repository 메서드로 조회
+  - Tool 계층에서 부모와 자식을 각각 조회하여 Service에서 조합
+
+#### 예시
+```kotlin
+// ❌ 잘못된 예시 - OneToMany 사용
+@Entity
+class FanNote {
+    @OneToMany(mappedBy = "fanNote")
+    val pages: List<FanNotePage> = mutableListOf()
+}
+
+// ✅ 올바른 예시 - ManyToOne만 사용
+@Entity
+class FanNotePage {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fan_note_id")
+    var fanNote: FanNote? = null
+}
+
+// Tool 계층에서 별도 조회
+class FanNoteReader {
+    fun findById(id: Long): FanNote { ... }
+    fun findPagesByFanNoteId(fanNoteId: Long): List<FanNotePage> { ... }
+}
+```
+
 ### Layer Architecture
 
 이 프로젝트는 명확한 계층 구조를 따릅니다. 각 계층은 특정한 의존성 규칙을 준수해야 합니다:

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -155,6 +155,21 @@ operation::daily-message-reply-create[snippets='http-request,path-parameters,req
 
 operation::daily-message-comment-update[snippets='http-request,path-parameters,request-headers,request-fields,http-response,response-fields']
 
+[[fan-note-api]]
+== 덕질노트 API
+
+=== 덕질노트 목록 조회
+
+덕질노트 목록을 페이지네이션과 함께 조회합니다. 제작일 기준 최신순으로 정렬됩니다.
+
+operation::fan-note-list[snippets='http-request,query-parameters,http-response,response-fields']
+
+=== 덕질노트 상세 조회
+
+특정 덕질노트의 상세 정보와 페이지 목록을 조회합니다. 각 페이지는 S3에 저장된 이미지 URL로 구성됩니다.
+
+operation::fan-note-detail[snippets='http-request,path-parameters,http-response,response-fields']
+
 [[like-api]]
 == 좋아요 API
 

--- a/src/main/kotlin/com/example/mykku/auth/AuthService.kt
+++ b/src/main/kotlin/com/example/mykku/auth/AuthService.kt
@@ -59,29 +59,32 @@ class AuthService(
 
     private fun handleGoogleMobileLogin(accessToken: String): LoginResponse {
         val userInfo = googleOauthClient.verifyAndGetUserInfo(accessToken)
-        val member = createOrUpdateMember(userInfo)
-        return jwtTokenProvider.createLoginResponse(member, userInfo.email)
+        val (member, isExistingUser) = createOrUpdateMember(userInfo)
+        return jwtTokenProvider.createLoginResponse(member, userInfo.email, isExistingUser)
     }
 
     private fun handleKakaoMobileLogin(accessToken: String): LoginResponse {
         val userInfo = kakaoOauthClient.verifyAndGetUserInfo(accessToken)
-        val member = createOrUpdateKakaoMember(userInfo)
+        val (member, isExistingUser) = createOrUpdateKakaoMember(userInfo)
         val email = userInfo.kakaoAccount?.email ?: "kakao_${userInfo.id}@kakao.com"
-        return jwtTokenProvider.createLoginResponse(member, email)
+        return jwtTokenProvider.createLoginResponse(member, email, isExistingUser)
     }
 
     private fun handleAppleMobileLogin(idToken: String): LoginResponse {
         val userInfo = appleOauthClient.verifyAndGetUserInfo(idToken)
-        val member = createOrUpdateAppleMember(userInfo)
+        val (member, isExistingUser) = createOrUpdateAppleMember(userInfo)
         val email = userInfo.email ?: "apple_${userInfo.sub}@privaterelay.appleid.com"
-        return jwtTokenProvider.createLoginResponse(member, email)
+        return jwtTokenProvider.createLoginResponse(member, email, isExistingUser)
     }
 
-    private fun createOrUpdateMember(userInfo: GoogleUserInfo): Member {
+    private fun createOrUpdateMember(userInfo: GoogleUserInfo): Pair<Member, Boolean> {
         val memberId = "google_${userInfo.id}"
+        val existingMember = memberReader.findById(memberId)
 
-        return memberReader.findById(memberId).orElseGet {
-            createNewMember(
+        return if (existingMember.isPresent) {
+            Pair(existingMember.get(), true)
+        } else {
+            val newMember = createNewMember(
                 id = memberId,
                 nickname = userInfo.name,
                 profileImage = userInfo.picture ?: "",
@@ -89,17 +92,21 @@ class AuthService(
                 socialId = userInfo.id,
                 email = userInfo.email
             )
+            Pair(newMember, false)
         }
     }
 
-    private fun createOrUpdateKakaoMember(userInfo: KakaoUserInfo): Member {
+    private fun createOrUpdateKakaoMember(userInfo: KakaoUserInfo): Pair<Member, Boolean> {
         val memberId = "kakao_${userInfo.id}"
         val nickname = userInfo.properties?.nickname ?: userInfo.kakaoAccount?.profile?.nickname ?: "카카오사용자"
         val profileImage = userInfo.properties?.profileImage ?: userInfo.kakaoAccount?.profile?.profileImageUrl ?: ""
         val email = userInfo.kakaoAccount?.email ?: "kakao_${userInfo.id}@kakao.com"
+        val existingMember = memberReader.findById(memberId)
 
-        return memberReader.findById(memberId).orElseGet {
-            createNewMember(
+        return if (existingMember.isPresent) {
+            Pair(existingMember.get(), true)
+        } else {
+            val newMember = createNewMember(
                 id = memberId,
                 nickname = nickname,
                 profileImage = profileImage,
@@ -107,17 +114,21 @@ class AuthService(
                 socialId = userInfo.id.toString(),
                 email = email
             )
+            Pair(newMember, false)
         }
     }
 
 
-    private fun createOrUpdateAppleMember(userInfo: AppleUserInfo): Member {
+    private fun createOrUpdateAppleMember(userInfo: AppleUserInfo): Pair<Member, Boolean> {
         val memberId = "apple_${userInfo.sub}"
         val nickname = "애플사용자"
         val email = userInfo.email ?: "apple_${userInfo.sub}@privaterelay.appleid.com"
+        val existingMember = memberReader.findById(memberId)
 
-        return memberReader.findById(memberId).orElseGet {
-            createNewMember(
+        return if (existingMember.isPresent) {
+            Pair(existingMember.get(), true)
+        } else {
+            val newMember = createNewMember(
                 id = memberId,
                 nickname = nickname,
                 profileImage = "",
@@ -125,6 +136,7 @@ class AuthService(
                 socialId = userInfo.sub,
                 email = email
             )
+            Pair(newMember, false)
         }
     }
 

--- a/src/main/kotlin/com/example/mykku/auth/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/example/mykku/auth/dto/LoginResponse.kt
@@ -6,5 +6,6 @@ data class LoginResponse(
     val tokenType: String = "Bearer",
     val accessTokenExpiresIn: Long,
     val refreshTokenExpiresIn: Long,
-    val member: MemberInfo
+    val member: MemberInfo,
+    val isExistingUser: Boolean
 )

--- a/src/main/kotlin/com/example/mykku/auth/tool/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/example/mykku/auth/tool/JwtTokenProvider.kt
@@ -45,7 +45,7 @@ class JwtTokenProvider(
             .compact()
     }
 
-    fun createLoginResponse(member: Member, userEmail: String): LoginResponse {
+    fun createLoginResponse(member: Member, userEmail: String, isExistingUser: Boolean): LoginResponse {
         val accessToken = generateAccessToken(member.id, userEmail)
         val refreshToken = generateRefreshToken(member.id)
 
@@ -59,7 +59,8 @@ class JwtTokenProvider(
                 email = userEmail,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = isExistingUser
         )
     }
 

--- a/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/exception/ErrorCode.kt
@@ -90,4 +90,8 @@ enum class ErrorCode(val status: HttpStatus, val message: String) {
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+
+    // FanNote
+    FAN_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "덕질노트를 찾을 수 없습니다"),
+    FAN_NOTE_PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "덕질노트 페이지를 찾을 수 없습니다"),
 }

--- a/src/main/kotlin/com/example/mykku/fannote/FanNoteController.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/FanNoteController.kt
@@ -1,0 +1,49 @@
+package com.example.mykku.fannote
+
+import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.common.util.PageableValidator
+import com.example.mykku.fannote.dto.FanNoteDetailResponse
+import com.example.mykku.fannote.dto.FanNoteListResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Sort
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/fan-notes")
+class FanNoteController(
+    private val fanNoteService: FanNoteService
+) {
+
+    @GetMapping
+    fun getFanNoteList(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ApiResponse<Page<FanNoteListResponse>> {
+        val pageable = PageableValidator.validateAndCreate(
+            page = page,
+            size = size,
+            sortProperty = "productionDate",
+            direction = Sort.Direction.DESC
+        )
+        val fanNotes = fanNoteService.getFanNoteList(pageable)
+        return ApiResponse(
+            message = "덕질노트 목록 조회 성공",
+            data = fanNotes
+        )
+    }
+
+    @GetMapping("/{fanNoteId}")
+    fun getFanNoteDetail(
+        @PathVariable fanNoteId: Long
+    ): ApiResponse<FanNoteDetailResponse> {
+        val fanNoteDetail = fanNoteService.getFanNoteDetail(fanNoteId)
+        return ApiResponse(
+            message = "덕질노트 상세 조회 성공",
+            data = fanNoteDetail
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/FanNoteService.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/FanNoteService.kt
@@ -20,7 +20,8 @@ class FanNoteService(
     }
 
     fun getFanNoteDetail(fanNoteId: Long): FanNoteDetailResponse {
-        val fanNote = fanNoteReader.findByIdWithPages(fanNoteId)
-        return FanNoteDetailResponse.from(fanNote)
+        val fanNote = fanNoteReader.findById(fanNoteId)
+        val pages = fanNoteReader.findPagesByFanNoteId(fanNoteId)
+        return FanNoteDetailResponse.from(fanNote, pages)
     }
 }

--- a/src/main/kotlin/com/example/mykku/fannote/FanNoteService.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/FanNoteService.kt
@@ -1,0 +1,26 @@
+package com.example.mykku.fannote
+
+import com.example.mykku.fannote.dto.FanNoteDetailResponse
+import com.example.mykku.fannote.dto.FanNoteListResponse
+import com.example.mykku.fannote.tool.FanNoteReader
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class FanNoteService(
+    private val fanNoteReader: FanNoteReader
+) {
+
+    fun getFanNoteList(pageable: Pageable): Page<FanNoteListResponse> {
+        val fanNotes = fanNoteReader.findAllWithPagination(pageable)
+        return fanNotes.map { FanNoteListResponse.from(it) }
+    }
+
+    fun getFanNoteDetail(fanNoteId: Long): FanNoteDetailResponse {
+        val fanNote = fanNoteReader.findByIdWithPages(fanNoteId)
+        return FanNoteDetailResponse.from(fanNote)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/domain/FanNote.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/domain/FanNote.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.*
 import java.time.LocalDate
 
 @Entity
-@Table(name = "fan_notes")
 class FanNote(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,16 +23,8 @@ class FanNote(
     var productionDate: LocalDate,
 
     @Column(nullable = true, length = 500)
-    var coverImageUrl: String? = null,
-
-    @OneToMany(mappedBy = "fanNote", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val pages: MutableList<FanNotePage> = mutableListOf()
+    var coverImageUrl: String? = null
 ) : BaseEntity() {
-
-    fun addPage(page: FanNotePage) {
-        pages.add(page)
-        page.fanNote = this
-    }
 
     fun updateInfo(
         title: String,

--- a/src/main/kotlin/com/example/mykku/fannote/domain/FanNote.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/domain/FanNote.kt
@@ -1,0 +1,51 @@
+package com.example.mykku.fannote.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(name = "fan_notes")
+class FanNote(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, length = 100)
+    var title: String,
+
+    @Column(nullable = true, length = 200)
+    var subtitle: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var content: String? = null,
+
+    @Column(nullable = false)
+    var productionDate: LocalDate,
+
+    @Column(nullable = true, length = 500)
+    var coverImageUrl: String? = null,
+
+    @OneToMany(mappedBy = "fanNote", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val pages: MutableList<FanNotePage> = mutableListOf()
+) : BaseEntity() {
+
+    fun addPage(page: FanNotePage) {
+        pages.add(page)
+        page.fanNote = this
+    }
+
+    fun updateInfo(
+        title: String,
+        subtitle: String?,
+        content: String?,
+        productionDate: LocalDate,
+        coverImageUrl: String?
+    ) {
+        this.title = title
+        this.subtitle = subtitle
+        this.content = content
+        this.productionDate = productionDate
+        this.coverImageUrl = coverImageUrl
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.fannote.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "fan_note_pages")
+class FanNotePage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false)
+    var pageNumber: Int,
+
+    @Column(nullable = false, length = 500)
+    var imageUrl: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fan_note_id", nullable = false)
+    var fanNote: FanNote? = null
+) : BaseEntity() {
+
+    fun updatePage(pageNumber: Int, imageUrl: String) {
+        this.pageNumber = pageNumber
+        this.imageUrl = imageUrl
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
@@ -17,7 +17,7 @@ class FanNotePage(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fan_note_id", nullable = false)
-    var fanNote: FanNote? = null
+    var fanNote: FanNote
 ) : BaseEntity() {
 
     fun updatePage(pageNumber: Int, imageUrl: String) {

--- a/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/domain/FanNotePage.kt
@@ -4,7 +4,6 @@ import com.example.mykku.common.domain.BaseEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "fan_note_pages")
 class FanNotePage(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteDetailResponse.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteDetailResponse.kt
@@ -1,6 +1,7 @@
 package com.example.mykku.fannote.dto
 
 import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
 
 data class FanNoteDetailResponse(
     val id: Long,
@@ -12,7 +13,7 @@ data class FanNoteDetailResponse(
     val pages: List<FanNotePageResponse>
 ) {
     companion object {
-        fun from(fanNote: FanNote): FanNoteDetailResponse {
+        fun from(fanNote: FanNote, pages: List<FanNotePage>): FanNoteDetailResponse {
             return FanNoteDetailResponse(
                 id = fanNote.id,
                 title = fanNote.title,
@@ -20,7 +21,7 @@ data class FanNoteDetailResponse(
                 content = fanNote.content,
                 productionDate = fanNote.productionDate.toString(),
                 coverImageUrl = fanNote.coverImageUrl,
-                pages = fanNote.pages
+                pages = pages
                     .sortedBy { it.pageNumber }
                     .map { FanNotePageResponse.from(it) }
             )

--- a/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteDetailResponse.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteDetailResponse.kt
@@ -1,0 +1,29 @@
+package com.example.mykku.fannote.dto
+
+import com.example.mykku.fannote.domain.FanNote
+
+data class FanNoteDetailResponse(
+    val id: Long,
+    val title: String,
+    val subtitle: String?,
+    val content: String?,
+    val productionDate: String,
+    val coverImageUrl: String?,
+    val pages: List<FanNotePageResponse>
+) {
+    companion object {
+        fun from(fanNote: FanNote): FanNoteDetailResponse {
+            return FanNoteDetailResponse(
+                id = fanNote.id,
+                title = fanNote.title,
+                subtitle = fanNote.subtitle,
+                content = fanNote.content,
+                productionDate = fanNote.productionDate.toString(),
+                coverImageUrl = fanNote.coverImageUrl,
+                pages = fanNote.pages
+                    .sortedBy { it.pageNumber }
+                    .map { FanNotePageResponse.from(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteListResponse.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/dto/FanNoteListResponse.kt
@@ -1,0 +1,25 @@
+package com.example.mykku.fannote.dto
+
+import com.example.mykku.fannote.domain.FanNote
+
+data class FanNoteListResponse(
+    val id: Long,
+    val title: String,
+    val subtitle: String?,
+    val content: String?,
+    val productionDate: String,
+    val coverImageUrl: String?
+) {
+    companion object {
+        fun from(fanNote: FanNote): FanNoteListResponse {
+            return FanNoteListResponse(
+                id = fanNote.id,
+                title = fanNote.title,
+                subtitle = fanNote.subtitle,
+                content = fanNote.content,
+                productionDate = fanNote.productionDate.toString(),
+                coverImageUrl = fanNote.coverImageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/dto/FanNotePageResponse.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/dto/FanNotePageResponse.kt
@@ -1,0 +1,17 @@
+package com.example.mykku.fannote.dto
+
+import com.example.mykku.fannote.domain.FanNotePage
+
+data class FanNotePageResponse(
+    val pageNumber: Int,
+    val imageUrl: String
+) {
+    companion object {
+        fun from(fanNotePage: FanNotePage): FanNotePageResponse {
+            return FanNotePageResponse(
+                pageNumber = fanNotePage.pageNumber,
+                imageUrl = fanNotePage.imageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/repository/FanNotePageRepository.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/repository/FanNotePageRepository.kt
@@ -1,0 +1,10 @@
+package com.example.mykku.fannote.repository
+
+import com.example.mykku.fannote.domain.FanNotePage
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FanNotePageRepository : JpaRepository<FanNotePage, Long> {
+    fun findByFanNoteIdOrderByPageNumber(fanNoteId: Long): List<FanNotePage>
+}

--- a/src/main/kotlin/com/example/mykku/fannote/repository/FanNoteRepository.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/repository/FanNoteRepository.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.fannote.repository
+
+import com.example.mykku.fannote.domain.FanNote
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FanNoteRepository : JpaRepository<FanNote, Long> {
+
+    @Query("SELECT fn FROM FanNote fn ORDER BY fn.productionDate DESC, fn.createdAt DESC")
+    fun findAllOrderByProductionDateDesc(pageable: Pageable): Page<FanNote>
+
+    @Query("SELECT fn FROM FanNote fn LEFT JOIN FETCH fn.pages WHERE fn.id = :id")
+    fun findByIdWithPages(@Param("id") id: Long): FanNote?
+}

--- a/src/main/kotlin/com/example/mykku/fannote/repository/FanNoteRepository.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/repository/FanNoteRepository.kt
@@ -1,19 +1,8 @@
 package com.example.mykku.fannote.repository
 
 import com.example.mykku.fannote.domain.FanNote
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
-interface FanNoteRepository : JpaRepository<FanNote, Long> {
-
-    @Query("SELECT fn FROM FanNote fn ORDER BY fn.productionDate DESC, fn.createdAt DESC")
-    fun findAllOrderByProductionDateDesc(pageable: Pageable): Page<FanNote>
-
-    @Query("SELECT fn FROM FanNote fn LEFT JOIN FETCH fn.pages WHERE fn.id = :id")
-    fun findByIdWithPages(@Param("id") id: Long): FanNote?
-}
+interface FanNoteRepository : JpaRepository<FanNote, Long>

--- a/src/main/kotlin/com/example/mykku/fannote/tool/FanNoteReader.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/tool/FanNoteReader.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.fannote.tool
+
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.repository.FanNoteRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+
+@Component
+class FanNoteReader(
+    private val fanNoteRepository: FanNoteRepository
+) {
+
+    fun findAllWithPagination(pageable: Pageable): Page<FanNote> {
+        return fanNoteRepository.findAllOrderByProductionDateDesc(pageable)
+    }
+
+    fun findByIdWithPages(id: Long): FanNote {
+        return fanNoteRepository.findByIdWithPages(id)
+            ?: throw MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND)
+    }
+
+    fun existsById(id: Long): Boolean {
+        return fanNoteRepository.existsById(id)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/fannote/tool/FanNoteReader.kt
+++ b/src/main/kotlin/com/example/mykku/fannote/tool/FanNoteReader.kt
@@ -3,23 +3,31 @@ package com.example.mykku.fannote.tool
 import com.example.mykku.exception.ErrorCode
 import com.example.mykku.exception.MykkuException
 import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
 import com.example.mykku.fannote.repository.FanNoteRepository
+import com.example.mykku.fannote.repository.FanNotePageRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
 class FanNoteReader(
-    private val fanNoteRepository: FanNoteRepository
+    private val fanNoteRepository: FanNoteRepository,
+    private val fanNotePageRepository: FanNotePageRepository
 ) {
 
     fun findAllWithPagination(pageable: Pageable): Page<FanNote> {
-        return fanNoteRepository.findAllOrderByProductionDateDesc(pageable)
+        return fanNoteRepository.findAll(pageable)
     }
 
-    fun findByIdWithPages(id: Long): FanNote {
-        return fanNoteRepository.findByIdWithPages(id)
-            ?: throw MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND)
+    fun findById(id: Long): FanNote {
+        return fanNoteRepository.findById(id).orElseThrow {
+            MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND)
+        }
+    }
+
+    fun findPagesByFanNoteId(fanNoteId: Long): List<FanNotePage> {
+        return fanNotePageRepository.findByFanNoteIdOrderByPageNumber(fanNoteId)
     }
 
     fun existsById(id: Long): Boolean {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -229,6 +229,29 @@ CREATE TABLE IF NOT EXISTS contest_winner (
     FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE
 );
 
+-- Create FanNotes table
+CREATE TABLE IF NOT EXISTS fan_note (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,
+    subtitle VARCHAR(200),
+    content TEXT,
+    production_date DATE NOT NULL,
+    cover_image_url VARCHAR(500),
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL
+);
+
+-- Create FanNotePages table
+CREATE TABLE IF NOT EXISTS fan_note_page (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    page_number INT NOT NULL,
+    image_url VARCHAR(500) NOT NULL,
+    fan_note_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    FOREIGN KEY (fan_note_id) REFERENCES fan_notes(id) ON DELETE CASCADE
+);
+
 -- Create indexes for better performance
 CREATE INDEX idx_feed_board_id ON feed(board_id);
 CREATE INDEX idx_feed_member_id ON feed(member_id);
@@ -239,3 +262,5 @@ CREATE INDEX idx_daily_message_comment_member_id ON daily_message_comment(member
 CREATE INDEX idx_follow_follower_id ON follow(follower_id);
 CREATE INDEX idx_follow_following_id ON follow(following_id);
 CREATE INDEX idx_daily_message_date ON daily_message(date);
+CREATE INDEX idx_fan_note_pages_fan_note_id ON fan_note_page(fan_note_id);
+CREATE INDEX idx_fan_notes_production_date ON fan_note(production_date);

--- a/src/test/kotlin/com/example/mykku/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthServiceTest.kt
@@ -79,12 +79,13 @@ class AuthServiceTest {
                 email = member.email,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = true
         )
 
         whenever(googleOauthClient.verifyAndGetUserInfo("google_token")).thenReturn(userInfo)
         whenever(memberReader.findById("google_123456")).thenReturn(Optional.of(member))
-        whenever(jwtTokenProvider.createLoginResponse(member, userInfo.email)).thenReturn(loginResponse)
+        whenever(jwtTokenProvider.createLoginResponse(member, userInfo.email, true)).thenReturn(loginResponse)
 
         // when
         val result = authService.handleMobileLogin(request)
@@ -141,12 +142,13 @@ class AuthServiceTest {
                 email = member.email,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = true
         )
 
         whenever(kakaoOauthClient.verifyAndGetUserInfo("kakao_token")).thenReturn(userInfo)
         whenever(memberReader.findById("kakao_123456")).thenReturn(Optional.of(member))
-        whenever(jwtTokenProvider.createLoginResponse(member, "test@kakao.com")).thenReturn(loginResponse)
+        whenever(jwtTokenProvider.createLoginResponse(member, "test@kakao.com", true)).thenReturn(loginResponse)
 
         // when
         val result = authService.handleMobileLogin(request)
@@ -183,7 +185,8 @@ class AuthServiceTest {
                 email = member.email,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = true
         )
 
         whenever(appleOauthClient.verifyAndGetUserInfo("apple_token")).thenReturn(userInfo)
@@ -191,7 +194,8 @@ class AuthServiceTest {
         whenever(
             jwtTokenProvider.createLoginResponse(
                 member,
-                "test@privaterelay.appleid.com"
+                "test@privaterelay.appleid.com",
+                true
             )
         ).thenReturn(loginResponse)
 
@@ -246,13 +250,14 @@ class AuthServiceTest {
                 email = newMember.email,
                 nickname = newMember.nickname,
                 profileImage = newMember.profileImage
-            )
+            ),
+            isExistingUser = false
         )
 
         whenever(googleOauthClient.verifyAndGetUserInfo("google_token")).thenReturn(userInfo)
         whenever(memberReader.findById("google_123456")).thenReturn(Optional.empty())
         whenever(memberWriter.save(any<Member>())).thenReturn(newMember)
-        whenever(jwtTokenProvider.createLoginResponse(newMember, userInfo.email)).thenReturn(loginResponse)
+        whenever(jwtTokenProvider.createLoginResponse(newMember, userInfo.email, false)).thenReturn(loginResponse)
 
         // when
         val request = MobileLoginRequest(provider = SocialProvider.GOOGLE, accessToken = "google_token", idToken = null)
@@ -309,12 +314,13 @@ class AuthServiceTest {
                 email = member.email,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = true
         )
 
         whenever(kakaoOauthClient.verifyAndGetUserInfo("kakao_token")).thenReturn(userInfo)
         whenever(memberReader.findById("kakao_123456")).thenReturn(Optional.of(member))
-        whenever(jwtTokenProvider.createLoginResponse(member, "kakao_123456@kakao.com")).thenReturn(loginResponse)
+        whenever(jwtTokenProvider.createLoginResponse(member, "kakao_123456@kakao.com", true)).thenReturn(loginResponse)
 
         // when
         val request = MobileLoginRequest(provider = SocialProvider.KAKAO, accessToken = "kakao_token", idToken = null)
@@ -351,7 +357,8 @@ class AuthServiceTest {
                 email = member.email,
                 nickname = member.nickname,
                 profileImage = member.profileImage
-            )
+            ),
+            isExistingUser = true
         )
 
         whenever(appleOauthClient.verifyAndGetUserInfo("apple_token")).thenReturn(userInfo)
@@ -359,7 +366,8 @@ class AuthServiceTest {
         whenever(
             jwtTokenProvider.createLoginResponse(
                 member,
-                "apple_apple.user.123456@privaterelay.appleid.com"
+                "apple_apple.user.123456@privaterelay.appleid.com",
+                true
             )
         ).thenReturn(loginResponse)
 

--- a/src/test/kotlin/com/example/mykku/auth/tool/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/tool/JwtTokenProviderTest.kt
@@ -148,7 +148,7 @@ class JwtTokenProviderTest {
         val userEmail = "test@example.com"
 
         // when
-        val loginResponse = jwtTokenProvider.createLoginResponse(member, userEmail)
+        val loginResponse = jwtTokenProvider.createLoginResponse(member, userEmail, true)
 
         // then
         assertNotNull(loginResponse.accessToken)

--- a/src/test/kotlin/com/example/mykku/dailymessage/repository/DailyMessageCommentRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/repository/DailyMessageCommentRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.example.mykku.member.domain.SocialProvider
 import com.example.mykku.member.repository.MemberRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import java.time.LocalDate
 import kotlin.test.assertEquals
@@ -14,6 +15,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class DailyMessageCommentRepositoryTest {
 
     @Autowired

--- a/src/test/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/repository/DailyMessageRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.example.mykku.dailymessage.repository
 import com.example.mykku.dailymessage.domain.DailyMessage
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
@@ -10,6 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class DailyMessageRepositoryTest {
 
     @Autowired

--- a/src/test/kotlin/com/example/mykku/docs/AuthControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/AuthControllerRestDocsTest.kt
@@ -54,7 +54,8 @@ class AuthControllerRestDocsTest : BaseControllerRestDocsTest() {
                 email = "user@gmail.com",
                 nickname = "홍길동",
                 profileImage = "https://lh3.googleusercontent.com/profile.jpg"
-            )
+            ),
+            isExistingUser = true
         )
 
         `when`(authService.handleMobileLogin(request)).thenReturn(loginResponse)
@@ -92,7 +93,8 @@ class AuthControllerRestDocsTest : BaseControllerRestDocsTest() {
                         fieldWithPath("data.member.email").type(JsonFieldType.STRING).description("회원 이메일"),
                         fieldWithPath("data.member.nickname").type(JsonFieldType.STRING).description("회원 닉네임"),
                         fieldWithPath("data.member.profileImage").type(JsonFieldType.STRING).description("프로필 이미지 URL")
-                            .optional()
+                            .optional(),
+                        fieldWithPath("data.isExistingUser").type(JsonFieldType.BOOLEAN).description("기존 가입자 여부 (true: 기존 가입자, false: 신규 가입자)")
                     )
                 )
             )
@@ -117,7 +119,8 @@ class AuthControllerRestDocsTest : BaseControllerRestDocsTest() {
                 email = "user@kakao.com",
                 nickname = "카카오사용자",
                 profileImage = "http://k.kakaocdn.net/profile.jpg"
-            )
+            ),
+            isExistingUser = true
         )
 
         `when`(authService.handleMobileLogin(request)).thenReturn(loginResponse)
@@ -157,7 +160,8 @@ class AuthControllerRestDocsTest : BaseControllerRestDocsTest() {
                 email = "user@privaterelay.appleid.com",
                 nickname = "애플사용자",
                 profileImage = ""
-            )
+            ),
+            isExistingUser = true
         )
 
         `when`(authService.handleMobileLogin(request)).thenReturn(loginResponse)

--- a/src/test/kotlin/com/example/mykku/docs/FanNoteControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/FanNoteControllerRestDocsTest.kt
@@ -1,0 +1,210 @@
+package com.example.mykku.docs
+
+import com.example.mykku.BaseControllerRestDocsTest
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
+import com.example.mykku.fannote.FanNoteController
+import com.example.mykku.fannote.FanNoteService
+import com.example.mykku.fannote.dto.FanNoteDetailResponse
+import com.example.mykku.fannote.dto.FanNoteListResponse
+import com.example.mykku.fannote.dto.FanNotePageResponse
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+class FanNoteControllerRestDocsTest : BaseControllerRestDocsTest() {
+
+    @Mock
+    private lateinit var fanNoteService: FanNoteService
+
+    private lateinit var fanNoteController: FanNoteController
+
+    override fun createMockMvcBuilder(): StandaloneMockMvcBuilder {
+        fanNoteController = FanNoteController(fanNoteService)
+        return MockMvcBuilders.standaloneSetup(fanNoteController)
+    }
+
+    @Test
+    fun `덕질노트 목록 조회 API 문서화`() {
+        // given
+        val fanNoteList = listOf(
+            FanNoteListResponse(
+                id = 1L,
+                title = "첫 번째 덕질노트",
+                subtitle = "서브타이틀 1",
+                content = "덕질노트 내용입니다",
+                productionDate = "2024-01-15",
+                coverImageUrl = "https://s3.amazonaws.com/mykku/covers/cover1.jpg"
+            ),
+            FanNoteListResponse(
+                id = 2L,
+                title = "두 번째 덕질노트",
+                subtitle = "서브타이틀 2",
+                content = "또 다른 덕질노트 내용",
+                productionDate = "2024-01-10",
+                coverImageUrl = "https://s3.amazonaws.com/mykku/covers/cover2.jpg"
+            )
+        )
+        val fanNotePage = PageImpl(fanNoteList, PageRequest.of(0, 20), fanNoteList.size.toLong())
+
+        `when`(fanNoteService.getFanNoteList(any())).thenReturn(fanNotePage)
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/fan-notes")
+                .param("page", "0")
+                .param("size", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("덕질노트 목록 조회 성공"))
+            .andDo(
+                document(
+                    "fan-note-list",
+                    queryParameters(
+                        parameterWithName("page").description("페이지 번호 (0부터 시작, 기본값: 0)").optional(),
+                        parameterWithName("size").description("페이지 크기 (기본값: 20, 최대: 100)").optional()
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("덕질노트 목록"),
+                        fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).description("덕질노트 ID"),
+                        fieldWithPath("data.content[].title").type(JsonFieldType.STRING).description("덕질노트 제목"),
+                        fieldWithPath("data.content[].subtitle").type(JsonFieldType.STRING).description("서브 제목")
+                            .optional(),
+                        fieldWithPath("data.content[].content").type(JsonFieldType.STRING).description("덕질노트 내용")
+                            .optional(),
+                        fieldWithPath("data.content[].productionDate").type(JsonFieldType.STRING)
+                            .description("제작 날짜 (yyyy-MM-dd)"),
+                        fieldWithPath("data.content[].coverImageUrl").type(JsonFieldType.STRING)
+                            .description("표지 이미지 URL").optional(),
+                        fieldWithPath("data.pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
+                        fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.pageable.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                        fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 비어있음 여부"),
+                        fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬됨 여부"),
+                        fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                            .description("정렬되지 않음 여부"),
+                        fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER).description("오프셋"),
+                        fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN).description("페이징 여부"),
+                        fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이징되지 않음 여부"),
+                        fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER).description("전체 요소 수"),
+                        fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                        fieldWithPath("data.last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                        fieldWithPath("data.first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                        fieldWithPath("data.number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지 요소 수"),
+                        fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN).description("빈 페이지 여부"),
+                        fieldWithPath("data.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                        fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 비어있음 여부"),
+                        fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬됨 여부"),
+                        fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않음 여부")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `덕질노트 상세 조회 API 문서화`() {
+        // given
+        val fanNoteId = 1L
+        val fanNoteDetail = FanNoteDetailResponse(
+            id = fanNoteId,
+            title = "웹툰 스타일 덕질노트",
+            subtitle = "좌우로 넘기면서 보는 만화",
+            content = "네이버 웹툰처럼 옆으로 넘기면서 볼 수 있는 덕질 콘텐츠입니다",
+            productionDate = "2024-01-15",
+            coverImageUrl = "https://s3.amazonaws.com/mykku/covers/cover1.jpg",
+            pages = listOf(
+                FanNotePageResponse(1, "https://s3.amazonaws.com/mykku/pages/page1.jpg"),
+                FanNotePageResponse(2, "https://s3.amazonaws.com/mykku/pages/page2.jpg"),
+                FanNotePageResponse(3, "https://s3.amazonaws.com/mykku/pages/page3.jpg"),
+                FanNotePageResponse(4, "https://s3.amazonaws.com/mykku/pages/page4.jpg"),
+                FanNotePageResponse(5, "https://s3.amazonaws.com/mykku/pages/page5.jpg")
+            )
+        )
+
+        `when`(fanNoteService.getFanNoteDetail(fanNoteId)).thenReturn(fanNoteDetail)
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/fan-notes/{fanNoteId}", fanNoteId)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(jsonPath("$.message").value("덕질노트 상세 조회 성공"))
+            .andExpect(jsonPath("$.data.id").value(fanNoteId))
+            .andExpect(jsonPath("$.data.pages.length()").value(5))
+            .andDo(
+                document(
+                    "fan-note-detail",
+                    pathParameters(
+                        parameterWithName("fanNoteId").description("덕질노트 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("덕질노트 ID"),
+                        fieldWithPath("data.title").type(JsonFieldType.STRING).description("덕질노트 제목"),
+                        fieldWithPath("data.subtitle").type(JsonFieldType.STRING).description("서브 제목").optional(),
+                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("덕질노트 내용").optional(),
+                        fieldWithPath("data.productionDate").type(JsonFieldType.STRING)
+                            .description("제작 날짜 (yyyy-MM-dd)"),
+                        fieldWithPath("data.coverImageUrl").type(JsonFieldType.STRING).description("표지 이미지 URL")
+                            .optional(),
+                        fieldWithPath("data.pages[]").type(JsonFieldType.ARRAY).description("페이지 목록"),
+                        fieldWithPath("data.pages[].pageNumber").type(JsonFieldType.NUMBER).description("페이지 번호"),
+                        fieldWithPath("data.pages[].imageUrl").type(JsonFieldType.STRING)
+                            .description("페이지 이미지 URL (S3)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `존재하지 않는 덕질노트 조회 시 404 에러 문서화`() {
+        // given
+        val fanNoteId = 999L
+        `when`(fanNoteService.getFanNoteDetail(fanNoteId))
+            .thenThrow(MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND))
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/fan-notes/{fanNoteId}", fanNoteId)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("덕질노트를 찾을 수 없습니다"))
+            .andDo(
+                document(
+                    "fan-note-not-found",
+                    pathParameters(
+                        parameterWithName("fanNoteId").description("존재하지 않는 덕질노트 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/FanNoteControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/FanNoteControllerTest.kt
@@ -2,11 +2,12 @@ package com.example.mykku.fannote
 
 import com.example.mykku.fannote.domain.FanNote
 import com.example.mykku.fannote.domain.FanNotePage
+import com.example.mykku.fannote.repository.FanNotePageRepository
 import com.example.mykku.fannote.repository.FanNoteRepository
 import com.example.mykku.util.DatabaseCleaner
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -29,10 +30,12 @@ class FanNoteControllerTest {
     @Autowired
     private lateinit var fanNoteRepository: FanNoteRepository
 
+    @Autowired
+    private lateinit var fanNotePageRepository: FanNotePageRepository
+
     @BeforeEach
     fun setUp() {
         RestAssured.port = port
-        fanNoteRepository.deleteAll()
     }
 
     @Test
@@ -82,10 +85,30 @@ class FanNoteControllerTest {
             productionDate = LocalDate.of(2024, 1, 1),
             coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
         )
-        fanNote.addPage(FanNotePage(pageNumber = 1, imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg"))
-        fanNote.addPage(FanNotePage(pageNumber = 2, imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg"))
-        fanNote.addPage(FanNotePage(pageNumber = 3, imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg"))
         val savedFanNote = fanNoteRepository.save(fanNote)
+
+        // 페이지 데이터 별도 저장
+        fanNotePageRepository.save(
+            FanNotePage(
+                pageNumber = 1,
+                imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg",
+                fanNote = savedFanNote
+            )
+        )
+        fanNotePageRepository.save(
+            FanNotePage(
+                pageNumber = 2,
+                imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg",
+                fanNote = savedFanNote
+            )
+        )
+        fanNotePageRepository.save(
+            FanNotePage(
+                pageNumber = 3,
+                imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg",
+                fanNote = savedFanNote
+            )
+        )
 
         // when & then
         RestAssured.given()

--- a/src/test/kotlin/com/example/mykku/fannote/FanNoteControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/FanNoteControllerTest.kt
@@ -1,0 +1,191 @@
+package com.example.mykku.fannote
+
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
+import com.example.mykku.fannote.repository.FanNoteRepository
+import com.example.mykku.util.DatabaseCleaner
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDate
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ExtendWith(DatabaseCleaner::class)
+@DisplayName("FanNoteController 통합 테스트")
+class FanNoteControllerTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var fanNoteRepository: FanNoteRepository
+
+    @BeforeEach
+    fun setUp() {
+        RestAssured.port = port
+        fanNoteRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("덕질노트 목록 조회 - 정상 케이스")
+    fun `덕질노트 목록을 조회한다`() {
+        // given
+        val fanNote1 = FanNote(
+            title = "덕질노트 1",
+            subtitle = "서브타이틀 1",
+            content = "내용 1",
+            productionDate = LocalDate.of(2024, 1, 2),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover1.jpg"
+        )
+        val fanNote2 = FanNote(
+            title = "덕질노트 2",
+            subtitle = "서브타이틀 2",
+            content = "내용 2",
+            productionDate = LocalDate.of(2024, 1, 1),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover2.jpg"
+        )
+        fanNoteRepository.saveAll(listOf(fanNote1, fanNote2))
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes?page=0&size=20&sort=productionDate,desc")
+            .then()
+            .statusCode(200)
+            .body("message", equalTo("덕질노트 목록 조회 성공"))
+            .body("data.content.size()", equalTo(2))
+            .body("data.content[0].title", equalTo("덕질노트 1"))
+            .body("data.content[0].productionDate", equalTo("2024-01-02"))
+            .body("data.content[1].title", equalTo("덕질노트 2"))
+            .body("data.content[1].productionDate", equalTo("2024-01-01"))
+            .body("data.totalElements", equalTo(2))
+    }
+
+    @Test
+    @DisplayName("덕질노트 상세 조회 - 정상 케이스")
+    fun `덕질노트 상세 정보를 조회한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "덕질노트 상세",
+            subtitle = "서브타이틀",
+            content = "상세 내용",
+            productionDate = LocalDate.of(2024, 1, 1),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
+        )
+        fanNote.addPage(FanNotePage(pageNumber = 1, imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg"))
+        fanNote.addPage(FanNotePage(pageNumber = 2, imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg"))
+        fanNote.addPage(FanNotePage(pageNumber = 3, imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg"))
+        val savedFanNote = fanNoteRepository.save(fanNote)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes/${savedFanNote.id}")
+            .then()
+            .statusCode(200)
+            .body("message", equalTo("덕질노트 상세 조회 성공"))
+            .body("data.id", equalTo(savedFanNote.id.toInt()))
+            .body("data.title", equalTo("덕질노트 상세"))
+            .body("data.subtitle", equalTo("서브타이틀"))
+            .body("data.content", equalTo("상세 내용"))
+            .body("data.productionDate", equalTo("2024-01-01"))
+            .body("data.pages.size()", equalTo(3))
+            .body("data.pages[0].pageNumber", equalTo(1))
+            .body("data.pages[0].imageUrl", equalTo("https://s3.amazonaws.com/mykku/page1.jpg"))
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 덕질노트 조회 - 404 반환")
+    fun `존재하지 않는 덕질노트 조회 시 404를 반환한다`() {
+        // given
+        val nonExistentId = 999L
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes/$nonExistentId")
+            .then()
+            .statusCode(404)
+            .body("message", equalTo("덕질노트를 찾을 수 없습니다"))
+    }
+
+    @Test
+    @DisplayName("페이지네이션 파라미터 없이 덕질노트 목록 조회")
+    fun `페이지네이션 파라미터 없이 덕질노트 목록을 조회한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "덕질노트",
+            subtitle = null,
+            content = null,
+            productionDate = LocalDate.of(2024, 1, 1),
+            coverImageUrl = null
+        )
+        fanNoteRepository.save(fanNote)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes")
+            .then()
+            .statusCode(200)
+            .body("message", equalTo("덕질노트 목록 조회 성공"))
+            .body("data.content.size()", equalTo(1))
+            .body("data.content[0].title", equalTo("덕질노트"))
+    }
+
+    @Test
+    @DisplayName("빈 덕질노트 목록 조회")
+    fun `빈 덕질노트 목록을 조회한다`() {
+        // given - no data
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes")
+            .then()
+            .statusCode(200)
+            .body("message", equalTo("덕질노트 목록 조회 성공"))
+            .body("data.content.size()", equalTo(0))
+            .body("data.totalElements", equalTo(0))
+    }
+
+    @Test
+    @DisplayName("페이지가 없는 덕질노트 상세 조회")
+    fun `페이지가 없는 덕질노트 상세 정보를 조회한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "페이지 없는 덕질노트",
+            subtitle = null,
+            content = null,
+            productionDate = LocalDate.of(2024, 1, 1),
+            coverImageUrl = null
+        )
+        val savedFanNote = fanNoteRepository.save(fanNote)
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/v1/fan-notes/${savedFanNote.id}")
+            .then()
+            .statusCode(200)
+            .body("message", equalTo("덕질노트 상세 조회 성공"))
+            .body("data.id", equalTo(savedFanNote.id.toInt()))
+            .body("data.title", equalTo("페이지 없는 덕질노트"))
+            .body("data.pages.size()", equalTo(0))
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
@@ -58,10 +58,10 @@ class FanNoteServiceTest {
         val fanNote = createFanNote(fanNoteId, "덕질노트", LocalDate.of(2024, 1, 1))
         val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
         val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
-        fanNote.addPage(page1)
-        fanNote.addPage(page2)
+        val pages = listOf(page1, page2)
 
-        given(fanNoteReader.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+        given(fanNoteReader.findById(fanNoteId)).willReturn(fanNote)
+        given(fanNoteReader.findPagesByFanNoteId(fanNoteId)).willReturn(pages)
 
         // when
         val result = fanNoteService.getFanNoteDetail(fanNoteId)
@@ -74,14 +74,15 @@ class FanNoteServiceTest {
         assertThat(result.pages[0].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page1.jpg")
         assertThat(result.pages[1].pageNumber).isEqualTo(2)
 
-        verify(fanNoteReader).findByIdWithPages(fanNoteId)
+        verify(fanNoteReader).findById(fanNoteId)
+        verify(fanNoteReader).findPagesByFanNoteId(fanNoteId)
     }
 
     @Test
     fun `존재하지 않는 덕질노트 조회 시 예외가 발생한다`() {
         // given
         val fanNoteId = 999L
-        given(fanNoteReader.findByIdWithPages(fanNoteId)).willThrow(MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND))
+        given(fanNoteReader.findById(fanNoteId)).willThrow(MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND))
 
         // when & then
         assertThatThrownBy { fanNoteService.getFanNoteDetail(fanNoteId) }
@@ -114,7 +115,8 @@ class FanNoteServiceTest {
         val fanNoteId = 1L
         val fanNote = createFanNote(fanNoteId, "페이지 없는 덕질노트", LocalDate.of(2024, 1, 1))
 
-        given(fanNoteReader.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+        given(fanNoteReader.findById(fanNoteId)).willReturn(fanNote)
+        given(fanNoteReader.findPagesByFanNoteId(fanNoteId)).willReturn(emptyList())
 
         // when
         val result = fanNoteService.getFanNoteDetail(fanNoteId)
@@ -124,7 +126,8 @@ class FanNoteServiceTest {
         assertThat(result.title).isEqualTo("페이지 없는 덕질노트")
         assertThat(result.pages).isEmpty()
 
-        verify(fanNoteReader).findByIdWithPages(fanNoteId)
+        verify(fanNoteReader).findById(fanNoteId)
+        verify(fanNoteReader).findPagesByFanNoteId(fanNoteId)
     }
 
     private fun createFanNote(id: Long, title: String, productionDate: LocalDate): FanNote {

--- a/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
@@ -1,0 +1,140 @@
+package com.example.mykku.fannote
+
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
+import com.example.mykku.fannote.tool.FanNoteReader
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class FanNoteServiceTest {
+
+    @Mock
+    private lateinit var fanNoteReader: FanNoteReader
+
+    @InjectMocks
+    private lateinit var fanNoteService: FanNoteService
+
+    @Test
+    fun `덕질노트 목록을 페이지네이션하여 조회한다`() {
+        // given
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "productionDate"))
+        val fanNote1 = createFanNote(1L, "덕질노트1", LocalDate.of(2024, 1, 1))
+        val fanNote2 = createFanNote(2L, "덕질노트2", LocalDate.of(2024, 1, 2))
+        val fanNotePage = PageImpl(listOf(fanNote1, fanNote2), pageable, 2)
+
+        given(fanNoteReader.findAllWithPagination(pageable)).willReturn(fanNotePage)
+
+        // when
+        val result = fanNoteService.getFanNoteList(pageable)
+
+        // then
+        assertThat(result.content).hasSize(2)
+        assertThat(result.content[0].id).isEqualTo(1L)
+        assertThat(result.content[0].title).isEqualTo("덕질노트1")
+        assertThat(result.content[1].id).isEqualTo(2L)
+        assertThat(result.content[1].title).isEqualTo("덕질노트2")
+
+        verify(fanNoteReader).findAllWithPagination(pageable)
+    }
+
+    @Test
+    fun `덕질노트 상세 정보를 조회한다`() {
+        // given
+        val fanNoteId = 1L
+        val fanNote = createFanNote(fanNoteId, "덕질노트", LocalDate.of(2024, 1, 1))
+        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
+        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
+        fanNote.addPage(page1)
+        fanNote.addPage(page2)
+
+        given(fanNoteReader.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+
+        // when
+        val result = fanNoteService.getFanNoteDetail(fanNoteId)
+
+        // then
+        assertThat(result.id).isEqualTo(fanNoteId)
+        assertThat(result.title).isEqualTo("덕질노트")
+        assertThat(result.pages).hasSize(2)
+        assertThat(result.pages[0].pageNumber).isEqualTo(1)
+        assertThat(result.pages[0].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page1.jpg")
+        assertThat(result.pages[1].pageNumber).isEqualTo(2)
+
+        verify(fanNoteReader).findByIdWithPages(fanNoteId)
+    }
+
+    @Test
+    fun `존재하지 않는 덕질노트 조회 시 예외가 발생한다`() {
+        // given
+        val fanNoteId = 999L
+        given(fanNoteReader.findByIdWithPages(fanNoteId)).willThrow(MykkuException(ErrorCode.FAN_NOTE_NOT_FOUND))
+
+        // when & then
+        assertThatThrownBy { fanNoteService.getFanNoteDetail(fanNoteId) }
+            .isInstanceOf(MykkuException::class.java)
+            .hasMessageContaining("덕질노트를 찾을 수 없습니다")
+    }
+
+    @Test
+    fun `빈 덕질노트 목록을 조회한다`() {
+        // given
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "productionDate"))
+        val emptyPage = PageImpl<FanNote>(emptyList(), pageable, 0)
+
+        given(fanNoteReader.findAllWithPagination(pageable)).willReturn(emptyPage)
+
+        // when
+        val result = fanNoteService.getFanNoteList(pageable)
+
+        // then
+        assertThat(result.content).isEmpty()
+        assertThat(result.totalElements).isEqualTo(0)
+        assertThat(result.totalPages).isEqualTo(0)
+
+        verify(fanNoteReader).findAllWithPagination(pageable)
+    }
+
+    @Test
+    fun `페이지가 없는 덕질노트 상세 정보를 조회한다`() {
+        // given
+        val fanNoteId = 1L
+        val fanNote = createFanNote(fanNoteId, "페이지 없는 덕질노트", LocalDate.of(2024, 1, 1))
+
+        given(fanNoteReader.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+
+        // when
+        val result = fanNoteService.getFanNoteDetail(fanNoteId)
+
+        // then
+        assertThat(result.id).isEqualTo(fanNoteId)
+        assertThat(result.title).isEqualTo("페이지 없는 덕질노트")
+        assertThat(result.pages).isEmpty()
+
+        verify(fanNoteReader).findByIdWithPages(fanNoteId)
+    }
+
+    private fun createFanNote(id: Long, title: String, productionDate: LocalDate): FanNote {
+        return FanNote(
+            id = id,
+            title = title,
+            subtitle = "$title 서브타이틀",
+            content = "$title 내용",
+            productionDate = productionDate,
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover_$id.jpg"
+        )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/FanNoteServiceTest.kt
@@ -56,8 +56,9 @@ class FanNoteServiceTest {
         // given
         val fanNoteId = 1L
         val fanNote = createFanNote(fanNoteId, "덕질노트", LocalDate.of(2024, 1, 1))
-        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
-        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
+        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg", fanNote)
+        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg", fanNote)
+
         val pages = listOf(page1, page2)
 
         given(fanNoteReader.findById(fanNoteId)).willReturn(fanNote)

--- a/src/test/kotlin/com/example/mykku/fannote/repository/FanNotePageRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/repository/FanNotePageRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.example.mykku.fannote.repository
+
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import java.time.LocalDate
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class FanNotePageRepositoryTest {
+
+    @Autowired
+    private lateinit var fanNotePageRepository: FanNotePageRepository
+
+    @Autowired
+    private lateinit var fanNoteRepository: FanNoteRepository
+
+    @Autowired
+    private lateinit var testEntityManager: TestEntityManager
+
+    @Test
+    fun `덕질노트 ID로 페이지를 조회하면 페이지 번호 순으로 정렬된다`() {
+        // given
+        val fanNote = FanNote(
+            title = "테스트 덕질노트",
+            subtitle = "서브타이틀",
+            content = "내용",
+            productionDate = LocalDate.of(2024, 1, 10),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
+        )
+        val savedFanNote = fanNoteRepository.save(fanNote)
+
+        val page3 = FanNotePage(pageNumber = 3, imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg", fanNote = savedFanNote)
+        val page1 = FanNotePage(pageNumber = 1, imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg", fanNote = savedFanNote)
+        val page2 = FanNotePage(pageNumber = 2, imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg", fanNote = savedFanNote)
+
+        fanNotePageRepository.save(page3)
+        fanNotePageRepository.save(page1)
+        fanNotePageRepository.save(page2)
+
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val pages = fanNotePageRepository.findByFanNoteIdOrderByPageNumber(savedFanNote.id)
+
+        // then
+        assertThat(pages).hasSize(3)
+        assertThat(pages[0].pageNumber).isEqualTo(1)
+        assertThat(pages[1].pageNumber).isEqualTo(2)
+        assertThat(pages[2].pageNumber).isEqualTo(3)
+        assertThat(pages[0].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page1.jpg")
+        assertThat(pages[1].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page2.jpg")
+        assertThat(pages[2].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page3.jpg")
+    }
+
+    @Test
+    fun `존재하지 않는 덕질노트 ID로 페이지 조회 시 빈 리스트를 반환한다`() {
+        // given
+        val nonExistentId = 999L
+
+        // when
+        val pages = fanNotePageRepository.findByFanNoteIdOrderByPageNumber(nonExistentId)
+
+        // then
+        assertThat(pages).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.example.mykku.fannote.repository
 
 import com.example.mykku.fannote.domain.FanNote
-import com.example.mykku.fannote.domain.FanNotePage
+import com.example.mykku.util.DatabaseCleaner
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.domain.PageRequest
@@ -12,6 +14,8 @@ import org.springframework.data.domain.Sort
 import java.time.LocalDate
 
 @DataJpaTest
+@ExtendWith(DatabaseCleaner::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class FanNoteRepositoryTest {
 
     @Autowired
@@ -48,7 +52,7 @@ class FanNoteRepositoryTest {
     }
 
     @Test
-    fun `덕질노트와 페이지를 함께 저장하고 조회한다`() {
+    fun `덕질노트를 저장하고 ID로 조회한다`() {
         // given
         val fanNote = FanNote(
             title = "웹툰 스타일 덕질노트",
@@ -58,28 +62,18 @@ class FanNoteRepositoryTest {
             coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
         )
 
-        val page1 = FanNotePage(pageNumber = 1, imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg")
-        val page2 = FanNotePage(pageNumber = 2, imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg")
-        val page3 = FanNotePage(pageNumber = 3, imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg")
-
-        fanNote.addPage(page1)
-        fanNote.addPage(page2)
-        fanNote.addPage(page3)
-
         // when
         val savedFanNote = fanNoteRepository.save(fanNote)
         testEntityManager.flush()
         testEntityManager.clear()
 
-        val foundFanNote = fanNoteRepository.findByIdWithPages(savedFanNote.id)
+        val foundFanNote = fanNoteRepository.findById(savedFanNote.id).orElse(null)
 
         // then
         assertThat(foundFanNote).isNotNull
-        assertThat(foundFanNote!!.pages).hasSize(3)
-        assertThat(foundFanNote.pages[0].pageNumber).isEqualTo(1)
-        assertThat(foundFanNote.pages[1].pageNumber).isEqualTo(2)
-        assertThat(foundFanNote.pages[2].pageNumber).isEqualTo(3)
-        assertThat(foundFanNote.pages[0].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page1.jpg")
+        assertThat(foundFanNote.title).isEqualTo("웹툰 스타일 덕질노트")
+        assertThat(foundFanNote.subtitle).isEqualTo("옆으로 넘기는 만화")
+        assertThat(foundFanNote.content).isEqualTo("네이버 웹툰처럼 볼 수 있는 콘텐츠")
     }
 
     @Test
@@ -117,7 +111,8 @@ class FanNoteRepositoryTest {
 
         // when
         val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
-        val fanNotePage = fanNoteRepository.findAllOrderByProductionDateDesc(pageable)
+        val fanNotePage = fanNoteRepository.findAll(pageable)
+        println(fanNotePage.content.map { it.title })
 
         // then
         assertThat(fanNotePage.content).hasSize(3)
@@ -130,15 +125,15 @@ class FanNoteRepositoryTest {
     }
 
     @Test
-    fun `존재하지 않는 ID로 덕질노트 조회 시 null을 반환한다`() {
+    fun `존재하지 않는 ID로 덕질노트 조회 시 빈 Optional을 반환한다`() {
         // given
         val nonExistentId = 999L
 
         // when
-        val foundFanNote = fanNoteRepository.findByIdWithPages(nonExistentId)
+        val foundFanNote = fanNoteRepository.findById(nonExistentId)
 
         // then
-        assertThat(foundFanNote).isNull()
+        assertThat(foundFanNote).isEmpty
     }
 
     @Test
@@ -181,7 +176,8 @@ class FanNoteRepositoryTest {
 
         // when
         val firstPage = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
-        val result = fanNoteRepository.findAllOrderByProductionDateDesc(firstPage)
+        val result = fanNoteRepository.findAll(firstPage)
+        result.content.forEach { println(it.title) }
 
         // then
         assertThat(result.content).hasSize(10)

--- a/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
@@ -112,7 +112,6 @@ class FanNoteRepositoryTest {
         // when
         val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
         val fanNotePage = fanNoteRepository.findAll(pageable)
-        println(fanNotePage.content.map { it.title })
 
         // then
         assertThat(fanNotePage.content).hasSize(3)
@@ -177,7 +176,6 @@ class FanNoteRepositoryTest {
         // when
         val firstPage = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
         val result = fanNoteRepository.findAll(firstPage)
-        result.content.forEach { println(it.title) }
 
         // then
         assertThat(result.content).hasSize(10)

--- a/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/repository/FanNoteRepositoryTest.kt
@@ -1,0 +1,194 @@
+package com.example.mykku.fannote.repository
+
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.time.LocalDate
+
+@DataJpaTest
+class FanNoteRepositoryTest {
+
+    @Autowired
+    private lateinit var fanNoteRepository: FanNoteRepository
+
+    @Autowired
+    private lateinit var testEntityManager: TestEntityManager
+
+    @Test
+    fun `덕질노트를 저장하고 조회한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "테스트 덕질노트",
+            subtitle = "서브타이틀",
+            content = "덕질노트 내용",
+            productionDate = LocalDate.of(2024, 1, 15),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
+        )
+
+        // when
+        val savedFanNote = fanNoteRepository.save(fanNote)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        val foundFanNote = fanNoteRepository.findById(savedFanNote.id).orElse(null)
+
+        // then
+        assertThat(foundFanNote).isNotNull
+        assertThat(foundFanNote.title).isEqualTo("테스트 덕질노트")
+        assertThat(foundFanNote.subtitle).isEqualTo("서브타이틀")
+        assertThat(foundFanNote.content).isEqualTo("덕질노트 내용")
+        assertThat(foundFanNote.productionDate).isEqualTo(LocalDate.of(2024, 1, 15))
+        assertThat(foundFanNote.coverImageUrl).isEqualTo("https://s3.amazonaws.com/mykku/cover.jpg")
+    }
+
+    @Test
+    fun `덕질노트와 페이지를 함께 저장하고 조회한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "웹툰 스타일 덕질노트",
+            subtitle = "옆으로 넘기는 만화",
+            content = "네이버 웹툰처럼 볼 수 있는 콘텐츠",
+            productionDate = LocalDate.of(2024, 1, 10),
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover.jpg"
+        )
+
+        val page1 = FanNotePage(pageNumber = 1, imageUrl = "https://s3.amazonaws.com/mykku/page1.jpg")
+        val page2 = FanNotePage(pageNumber = 2, imageUrl = "https://s3.amazonaws.com/mykku/page2.jpg")
+        val page3 = FanNotePage(pageNumber = 3, imageUrl = "https://s3.amazonaws.com/mykku/page3.jpg")
+
+        fanNote.addPage(page1)
+        fanNote.addPage(page2)
+        fanNote.addPage(page3)
+
+        // when
+        val savedFanNote = fanNoteRepository.save(fanNote)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        val foundFanNote = fanNoteRepository.findByIdWithPages(savedFanNote.id)
+
+        // then
+        assertThat(foundFanNote).isNotNull
+        assertThat(foundFanNote!!.pages).hasSize(3)
+        assertThat(foundFanNote.pages[0].pageNumber).isEqualTo(1)
+        assertThat(foundFanNote.pages[1].pageNumber).isEqualTo(2)
+        assertThat(foundFanNote.pages[2].pageNumber).isEqualTo(3)
+        assertThat(foundFanNote.pages[0].imageUrl).isEqualTo("https://s3.amazonaws.com/mykku/page1.jpg")
+    }
+
+    @Test
+    fun `제작일 기준 내림차순으로 덕질노트 목록을 조회한다`() {
+        // given
+        val fanNote1 = FanNote(
+            title = "첫 번째 덕질노트",
+            subtitle = null,
+            content = "내용1",
+            productionDate = LocalDate.of(2024, 1, 10),
+            coverImageUrl = null
+        )
+
+        val fanNote2 = FanNote(
+            title = "두 번째 덕질노트",
+            subtitle = null,
+            content = "내용2",
+            productionDate = LocalDate.of(2024, 1, 15),
+            coverImageUrl = null
+        )
+
+        val fanNote3 = FanNote(
+            title = "세 번째 덕질노트",
+            subtitle = null,
+            content = "내용3",
+            productionDate = LocalDate.of(2024, 1, 5),
+            coverImageUrl = null
+        )
+
+        fanNoteRepository.save(fanNote1)
+        fanNoteRepository.save(fanNote2)
+        fanNoteRepository.save(fanNote3)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
+        val fanNotePage = fanNoteRepository.findAllOrderByProductionDateDesc(pageable)
+
+        // then
+        assertThat(fanNotePage.content).hasSize(3)
+        assertThat(fanNotePage.content[0].title).isEqualTo("두 번째 덕질노트")
+        assertThat(fanNotePage.content[0].productionDate).isEqualTo(LocalDate.of(2024, 1, 15))
+        assertThat(fanNotePage.content[1].title).isEqualTo("첫 번째 덕질노트")
+        assertThat(fanNotePage.content[1].productionDate).isEqualTo(LocalDate.of(2024, 1, 10))
+        assertThat(fanNotePage.content[2].title).isEqualTo("세 번째 덕질노트")
+        assertThat(fanNotePage.content[2].productionDate).isEqualTo(LocalDate.of(2024, 1, 5))
+    }
+
+    @Test
+    fun `존재하지 않는 ID로 덕질노트 조회 시 null을 반환한다`() {
+        // given
+        val nonExistentId = 999L
+
+        // when
+        val foundFanNote = fanNoteRepository.findByIdWithPages(nonExistentId)
+
+        // then
+        assertThat(foundFanNote).isNull()
+    }
+
+    @Test
+    fun `덕질노트 존재 여부를 확인한다`() {
+        // given
+        val fanNote = FanNote(
+            title = "존재 확인용 덕질노트",
+            subtitle = null,
+            content = null,
+            productionDate = LocalDate.of(2024, 1, 1),
+            coverImageUrl = null
+        )
+        val savedFanNote = fanNoteRepository.save(fanNote)
+        testEntityManager.flush()
+
+        // when
+        val exists = fanNoteRepository.existsById(savedFanNote.id)
+        val notExists = fanNoteRepository.existsById(999L)
+
+        // then
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+
+    @Test
+    fun `페이지네이션이 올바르게 동작한다`() {
+        // given
+        for (i in 1..25) {
+            val fanNote = FanNote(
+                title = "덕질노트 $i",
+                subtitle = null,
+                content = "내용 $i",
+                productionDate = LocalDate.of(2024, 1, i),
+                coverImageUrl = null
+            )
+            fanNoteRepository.save(fanNote)
+        }
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val firstPage = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "productionDate"))
+        val result = fanNoteRepository.findAllOrderByProductionDateDesc(firstPage)
+
+        // then
+        assertThat(result.content).hasSize(10)
+        assertThat(result.totalElements).isEqualTo(25)
+        assertThat(result.totalPages).isEqualTo(3)
+        assertThat(result.isFirst).isTrue()
+        assertThat(result.isLast).isFalse()
+        assertThat(result.content[0].title).isEqualTo("덕질노트 25")
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
@@ -1,0 +1,132 @@
+package com.example.mykku.fannote.tool
+
+import com.example.mykku.exception.ErrorCode
+import com.example.mykku.exception.MykkuException
+import com.example.mykku.fannote.domain.FanNote
+import com.example.mykku.fannote.domain.FanNotePage
+import com.example.mykku.fannote.repository.FanNoteRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class FanNoteReaderTest {
+
+    @Mock
+    private lateinit var fanNoteRepository: FanNoteRepository
+
+    @InjectMocks
+    private lateinit var fanNoteReader: FanNoteReader
+
+    @Test
+    fun `페이지네이션으로 덕질노트 목록을 조회한다`() {
+        // given
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "productionDate"))
+        val fanNote1 = createFanNote(1L, "덕질노트1", LocalDate.of(2024, 1, 15))
+        val fanNote2 = createFanNote(2L, "덕질노트2", LocalDate.of(2024, 1, 10))
+        val fanNotePage = PageImpl(listOf(fanNote1, fanNote2), pageable, 2)
+
+        given(fanNoteRepository.findAllOrderByProductionDateDesc(pageable)).willReturn(fanNotePage)
+
+        // when
+        val result = fanNoteReader.findAllWithPagination(pageable)
+
+        // then
+        assertThat(result.content).hasSize(2)
+        assertThat(result.content[0].id).isEqualTo(1L)
+        assertThat(result.content[0].title).isEqualTo("덕질노트1")
+        assertThat(result.content[1].id).isEqualTo(2L)
+        assertThat(result.content[1].title).isEqualTo("덕질노트2")
+        assertThat(result.totalElements).isEqualTo(2)
+
+        verify(fanNoteRepository).findAllOrderByProductionDateDesc(pageable)
+    }
+
+    @Test
+    fun `ID로 덕질노트와 페이지를 함께 조회한다`() {
+        // given
+        val fanNoteId = 1L
+        val fanNote = createFanNote(fanNoteId, "덕질노트", LocalDate.of(2024, 1, 15))
+        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
+        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
+        fanNote.addPage(page1)
+        fanNote.addPage(page2)
+
+        given(fanNoteRepository.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+
+        // when
+        val result = fanNoteReader.findByIdWithPages(fanNoteId)
+
+        // then
+        assertThat(result.id).isEqualTo(fanNoteId)
+        assertThat(result.title).isEqualTo("덕질노트")
+        assertThat(result.pages).hasSize(2)
+        assertThat(result.pages[0].pageNumber).isEqualTo(1)
+        assertThat(result.pages[1].pageNumber).isEqualTo(2)
+
+        verify(fanNoteRepository).findByIdWithPages(fanNoteId)
+    }
+
+    @Test
+    fun `존재하지 않는 덕질노트 조회 시 예외를 발생시킨다`() {
+        // given
+        val fanNoteId = 999L
+        given(fanNoteRepository.findByIdWithPages(fanNoteId)).willReturn(null)
+
+        // when & then
+        assertThatThrownBy { fanNoteReader.findByIdWithPages(fanNoteId) }
+            .isInstanceOf(MykkuException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAN_NOTE_NOT_FOUND)
+
+        verify(fanNoteRepository).findByIdWithPages(fanNoteId)
+    }
+
+    @Test
+    fun `덕질노트 존재 여부를 확인한다`() {
+        // given
+        val fanNoteId = 1L
+        given(fanNoteRepository.existsById(fanNoteId)).willReturn(true)
+
+        // when
+        val result = fanNoteReader.existsById(fanNoteId)
+
+        // then
+        assertThat(result).isTrue()
+        verify(fanNoteRepository).existsById(fanNoteId)
+    }
+
+    @Test
+    fun `존재하지 않는 덕질노트의 존재 여부를 확인한다`() {
+        // given
+        val fanNoteId = 999L
+        given(fanNoteRepository.existsById(fanNoteId)).willReturn(false)
+
+        // when
+        val result = fanNoteReader.existsById(fanNoteId)
+
+        // then
+        assertThat(result).isFalse()
+        verify(fanNoteRepository).existsById(fanNoteId)
+    }
+
+    private fun createFanNote(id: Long, title: String, productionDate: LocalDate): FanNote {
+        return FanNote(
+            id = id,
+            title = title,
+            subtitle = "$title 서브타이틀",
+            content = "$title 내용",
+            productionDate = productionDate,
+            coverImageUrl = "https://s3.amazonaws.com/mykku/cover_$id.jpg"
+        )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
@@ -4,8 +4,8 @@ import com.example.mykku.exception.ErrorCode
 import com.example.mykku.exception.MykkuException
 import com.example.mykku.fannote.domain.FanNote
 import com.example.mykku.fannote.domain.FanNotePage
-import com.example.mykku.fannote.repository.FanNoteRepository
 import com.example.mykku.fannote.repository.FanNotePageRepository
+import com.example.mykku.fannote.repository.FanNoteRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -78,8 +78,13 @@ class FanNoteReaderTest {
     fun `덕질노트 ID로 페이지 목록을 조회한다`() {
         // given
         val fanNoteId = 1L
-        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
-        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
+        val mockFanNote = FanNote(
+            id = fanNoteId,
+            title = "테스트 덕질노트",
+            productionDate = LocalDate.now()
+        )
+        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg", mockFanNote)
+        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg", mockFanNote)
         val pages = listOf(page1, page2)
 
         given(fanNotePageRepository.findByFanNoteIdOrderByPageNumber(fanNoteId)).willReturn(pages)

--- a/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/fannote/tool/FanNoteReaderTest.kt
@@ -5,6 +5,7 @@ import com.example.mykku.exception.MykkuException
 import com.example.mykku.fannote.domain.FanNote
 import com.example.mykku.fannote.domain.FanNotePage
 import com.example.mykku.fannote.repository.FanNoteRepository
+import com.example.mykku.fannote.repository.FanNotePageRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -25,6 +26,9 @@ class FanNoteReaderTest {
     @Mock
     private lateinit var fanNoteRepository: FanNoteRepository
 
+    @Mock
+    private lateinit var fanNotePageRepository: FanNotePageRepository
+
     @InjectMocks
     private lateinit var fanNoteReader: FanNoteReader
 
@@ -36,7 +40,7 @@ class FanNoteReaderTest {
         val fanNote2 = createFanNote(2L, "덕질노트2", LocalDate.of(2024, 1, 10))
         val fanNotePage = PageImpl(listOf(fanNote1, fanNote2), pageable, 2)
 
-        given(fanNoteRepository.findAllOrderByProductionDateDesc(pageable)).willReturn(fanNotePage)
+        given(fanNoteRepository.findAll(pageable)).willReturn(fanNotePage)
 
         // when
         val result = fanNoteReader.findAllWithPagination(pageable)
@@ -49,46 +53,60 @@ class FanNoteReaderTest {
         assertThat(result.content[1].title).isEqualTo("덕질노트2")
         assertThat(result.totalElements).isEqualTo(2)
 
-        verify(fanNoteRepository).findAllOrderByProductionDateDesc(pageable)
+        verify(fanNoteRepository).findAll(pageable)
     }
 
     @Test
-    fun `ID로 덕질노트와 페이지를 함께 조회한다`() {
+    fun `ID로 덕질노트를 조회한다`() {
         // given
         val fanNoteId = 1L
         val fanNote = createFanNote(fanNoteId, "덕질노트", LocalDate.of(2024, 1, 15))
-        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
-        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
-        fanNote.addPage(page1)
-        fanNote.addPage(page2)
 
-        given(fanNoteRepository.findByIdWithPages(fanNoteId)).willReturn(fanNote)
+        given(fanNoteRepository.findById(fanNoteId)).willReturn(java.util.Optional.of(fanNote))
 
         // when
-        val result = fanNoteReader.findByIdWithPages(fanNoteId)
+        val result = fanNoteReader.findById(fanNoteId)
 
         // then
         assertThat(result.id).isEqualTo(fanNoteId)
         assertThat(result.title).isEqualTo("덕질노트")
-        assertThat(result.pages).hasSize(2)
-        assertThat(result.pages[0].pageNumber).isEqualTo(1)
-        assertThat(result.pages[1].pageNumber).isEqualTo(2)
 
-        verify(fanNoteRepository).findByIdWithPages(fanNoteId)
+        verify(fanNoteRepository).findById(fanNoteId)
+    }
+
+    @Test
+    fun `덕질노트 ID로 페이지 목록을 조회한다`() {
+        // given
+        val fanNoteId = 1L
+        val page1 = FanNotePage(1L, 1, "https://s3.amazonaws.com/mykku/page1.jpg")
+        val page2 = FanNotePage(2L, 2, "https://s3.amazonaws.com/mykku/page2.jpg")
+        val pages = listOf(page1, page2)
+
+        given(fanNotePageRepository.findByFanNoteIdOrderByPageNumber(fanNoteId)).willReturn(pages)
+
+        // when
+        val result = fanNoteReader.findPagesByFanNoteId(fanNoteId)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].pageNumber).isEqualTo(1)
+        assertThat(result[1].pageNumber).isEqualTo(2)
+
+        verify(fanNotePageRepository).findByFanNoteIdOrderByPageNumber(fanNoteId)
     }
 
     @Test
     fun `존재하지 않는 덕질노트 조회 시 예외를 발생시킨다`() {
         // given
         val fanNoteId = 999L
-        given(fanNoteRepository.findByIdWithPages(fanNoteId)).willReturn(null)
+        given(fanNoteRepository.findById(fanNoteId)).willReturn(java.util.Optional.empty())
 
         // when & then
-        assertThatThrownBy { fanNoteReader.findByIdWithPages(fanNoteId) }
+        assertThatThrownBy { fanNoteReader.findById(fanNoteId) }
             .isInstanceOf(MykkuException::class.java)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAN_NOTE_NOT_FOUND)
 
-        verify(fanNoteRepository).findByIdWithPages(fanNoteId)
+        verify(fanNoteRepository).findById(fanNoteId)
     }
 
     @Test

--- a/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
@@ -3,12 +3,14 @@ package com.example.mykku.feed.repository
 import com.example.mykku.feed.domain.Event
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class EventRepositoryTest {
 
     @Autowired

--- a/src/test/kotlin/com/example/mykku/feed/repository/FeedCommentRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/repository/FeedCommentRepositoryTest.kt
@@ -9,12 +9,14 @@ import com.example.mykku.member.domain.SocialProvider
 import com.example.mykku.member.repository.MemberRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.PageRequest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class FeedCommentRepositoryTest {
 
     @Autowired

--- a/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
@@ -111,9 +111,6 @@ class HomeControllerTest {
             .then()
             .extract().response()
 
-        println("Status Code: ${response.statusCode}")
-        println("Response Body: ${response.body.asString()}")
-
         response.then()
             .statusCode(200)
             .body("message", equalTo("홈 데이터 불러오기에 성공했습니다."))

--- a/src/test/kotlin/com/example/mykku/util/DatabaseCleaner.kt
+++ b/src/test/kotlin/com/example/mykku/util/DatabaseCleaner.kt
@@ -26,16 +26,16 @@ class DatabaseCleaner : BeforeEachCallback {
     }
 
     private fun truncateTables(em: EntityManager) {
-        // H2 데이터베이스의 경우 외래 키 검사 비활성화
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate()
-        
+        // MySQL의 경우 외래 키 검사 비활성화
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate()
+
         val tableNames = findTableNames(em)
         tableNames.forEach { tableName ->
             em.createNativeQuery("TRUNCATE TABLE $tableName").executeUpdate()
         }
-        
-        // H2 데이터베이스의 경우 외래 키 검사 다시 활성화
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate()
+
+        // MySQL의 경우 외래 키 검사 다시 활성화
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate()
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -43,12 +43,12 @@ class DatabaseCleaner : BeforeEachCallback {
         val tableNameSelectQuery = """
             SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_SCHEMA = 'PUBLIC'
-            AND TABLE_TYPE = 'TABLE'
-            AND TABLE_NAME NOT LIKE 'FLYWAY_%'
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_TYPE = 'BASE TABLE'
+            AND TABLE_NAME NOT LIKE 'flyway_%'
         """.trimIndent()
 
-        return em.createNativeQuery(tableNameSelectQuery)
-            .resultList as List<String>
+        val results = em.createNativeQuery(tableNameSelectQuery).resultList
+        return results.map { it.toString() }
     }
 }

--- a/src/test/kotlin/com/example/mykku/util/TestTokenGenerator.kt
+++ b/src/test/kotlin/com/example/mykku/util/TestTokenGenerator.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 object TestTokenGenerator {
     
-    private const val SECRET_KEY = "test-secret-key-should-be-very-long-and-secure-at-least-32-characters-long"
+    private const val SECRET_KEY = "your-secret-key-should-be-very-long-and-secure-at-least-32-characters-long"
     private const val EXPIRATION_TIME = 86400000L // 24 hours
     
     private val secretKey = Keys.hmacShaKeyFor(SECRET_KEY.toByteArray())

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,32 +1,30 @@
 spring:
-  application:
-    name: mykku
+  config:
+    activate:
+      on-profile: test
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL
-    username: sa
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/mykku_test
+    username: root
     password:
-    driver-class-name: org.h2.Driver
-
   jpa:
-    hibernate:
-      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-  sql:
-    init:
-      mode: never
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
 
 jwt:
-  secret: test-secret-key-should-be-very-long-and-secure-at-least-32-characters-long
+  secret: ${JWT_SECRET:your-secret-key-should-be-very-long-and-secure-at-least-32-characters-long}
   access-token-expiration: 86400000 # 1 day
   refresh-token-expiration: 1209600000 # 14 days
 
 aws:
   s3:
-    enabled: false
-    access-key: test-access-key
-    secret-key: test-secret-key
-    region: ap-northeast-2
-    bucket-name: test-bucket
+    access-key: ${AWS_S3_ACCESS_KEY:your-s3-access-key}
+    secret-key: ${AWS_S3_SECRET_KEY:your-s3-secret-key}
+    region: ${AWS_S3_REGION:ap-northeast-2}
+    bucket-name: ${AWS_S3_BUCKET_NAME:mykku-bucket}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,4 +1,4 @@
--- H2 Test Database Schema for MYKKU Application
+-- MySQL Test Database Schema for MYKKU Application
 
 -- Create Member table
 CREATE TABLE IF NOT EXISTS member (
@@ -222,6 +222,29 @@ CREATE TABLE IF NOT EXISTS contest_winner (
     FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE
 );
 
+-- Create FanNotes table
+CREATE TABLE IF NOT EXISTS fan_note (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,
+    subtitle VARCHAR(200),
+    content TEXT,
+    production_date DATE NOT NULL,
+    cover_image_url VARCHAR(500),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+-- Create FanNotePages table
+CREATE TABLE IF NOT EXISTS fan_note_page (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    page_number INT NOT NULL,
+    image_url VARCHAR(500) NOT NULL,
+    fan_note_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    FOREIGN KEY (fan_note_id) REFERENCES fan_note(id) ON DELETE CASCADE
+);
+
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_feed_board_id ON feed(board_id);
 CREATE INDEX IF NOT EXISTS idx_feed_member_id ON feed(member_id);
@@ -232,3 +255,5 @@ CREATE INDEX IF NOT EXISTS idx_daily_message_comment_member_id ON daily_message_
 CREATE INDEX IF NOT EXISTS idx_follow_follower_id ON follow(follower_id);
 CREATE INDEX IF NOT EXISTS idx_follow_following_id ON follow(following_id);
 CREATE INDEX IF NOT EXISTS idx_daily_message_date ON daily_message(date);
+CREATE INDEX IF NOT EXISTS idx_fan_note_pages_fan_note_id ON fan_note_page(fan_note_id);
+CREATE INDEX IF NOT EXISTS idx_fan_note_production_date ON fan_note(production_date);


### PR DESCRIPTION
# 🚩 연관 이슈

closed #28 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 덕질노트 기능 추가: 목록/상세 조회(페이지 이미지 포함), 페이지네이션·제작일 최신순 정렬 제공.
  * 모바일 로그인 응답에 isExistingUser(Boolean) 필드 추가로 신규/기존 사용자 구분 제공.

* 문서
  * REST Docs에 덕질노트 API 문서 추가 및 좋아요/오류(400/404/500) 문서 확장; 인덱스 업데이트 지침 포함.

* 테스트/인프라
  * 신규 5계층 테스트 요구 사항 및 다수의 테스트 추가·수정, 테스트 환경을 MySQL로 전환하는 설정 변경.

* 예외/데이터
  * 덕질노트 관련 NotFound 오류 코드 추가; DB 스키마·초기화 스크립트와 인덱스 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->