### PR TITLE
[FEAT] 취향 저장 API

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -341,6 +341,45 @@ operation::scrap-fan-note-unsave[snippets='http-request,path-parameters,request-
 
 operation::scrap-fan-note-list[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
+[[preference-api]]
+== 취향 API
+
+=== 장르 취향 저장
+
+사용자의 장르 취향을 저장합니다. 기존 장르 취향은 모두 삭제되고 새로운 취향으로 대체됩니다.
+
+operation::preference-genre-update[snippets='http-request,request-headers,request-fields,http-response,response-fields']
+
+=== 장르 취향 조회
+
+사용자의 저장된 장르 취향을 조회합니다.
+
+operation::preference-genre-get[snippets='http-request,request-headers,http-response,response-fields']
+
+=== 굿즈 취향 저장
+
+사용자의 굿즈 취향을 저장합니다. 기존 굿즈 취향은 모두 삭제되고 새로운 취향으로 대체됩니다.
+
+operation::preference-goods-update[snippets='http-request,request-headers,request-fields,http-response,response-fields']
+
+=== 굿즈 취향 조회
+
+사용자의 저장된 굿즈 취향을 조회합니다.
+
+operation::preference-goods-get[snippets='http-request,request-headers,http-response,response-fields']
+
+=== 분위기 취향 저장
+
+사용자의 분위기 취향을 저장합니다. 기존 분위기 취향은 모두 삭제되고 새로운 취향으로 대체됩니다.
+
+operation::preference-mood-update[snippets='http-request,request-headers,request-fields,http-response,response-fields']
+
+=== 분위기 취향 조회
+
+사용자의 저장된 분위기 취향을 조회합니다.
+
+operation::preference-mood-get[snippets='http-request,request-headers,http-response,response-fields']
+
 [[error-api]]
 == 에러 응답
 

--- a/src/main/kotlin/com/example/mykku/preference/PreferenceController.kt
+++ b/src/main/kotlin/com/example/mykku/preference/PreferenceController.kt
@@ -1,0 +1,97 @@
+package com.example.mykku.preference
+
+import com.example.mykku.auth.config.CurrentMember
+import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.dto.*
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/preferences")
+class PreferenceController(
+    private val preferenceService: PreferenceService
+) {
+
+    @PostMapping("/genre")
+    fun updateGenrePreferences(
+        @RequestBody @Valid request: UpdateGenrePreferenceRequest,
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<Unit>> {
+        preferenceService.updateGenrePreferences(member, request.genreTypes)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "장르 취향이 성공적으로 저장되었습니다.",
+                data = Unit
+            )
+        )
+    }
+
+    @PostMapping("/goods")
+    fun updateGoodsPreferences(
+        @RequestBody @Valid request: UpdateGoodsPreferenceRequest,
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<Unit>> {
+        preferenceService.updateGoodsPreferences(member, request.goodsTypes)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "굿즈 취향이 성공적으로 저장되었습니다.",
+                data = Unit
+            )
+        )
+    }
+
+    @PostMapping("/mood")
+    fun updateMoodPreferences(
+        @RequestBody @Valid request: UpdateMoodPreferenceRequest,
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<Unit>> {
+        preferenceService.updateMoodPreferences(member, request.moodTypes)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "분위기 취향이 성공적으로 저장되었습니다.",
+                data = Unit
+            )
+        )
+    }
+
+    @GetMapping("/genre")
+    fun getGenrePreferences(
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<GenrePreferenceResponse>> {
+        val genreTypes = preferenceService.getGenrePreferences(member)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "장르 취향을 성공적으로 조회했습니다.",
+                data = GenrePreferenceResponse(genreTypes)
+            )
+        )
+    }
+
+    @GetMapping("/goods")
+    fun getGoodsPreferences(
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<GoodsPreferenceResponse>> {
+        val goodsTypes = preferenceService.getGoodsPreferences(member)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "굿즈 취향을 성공적으로 조회했습니다.",
+                data = GoodsPreferenceResponse(goodsTypes)
+            )
+        )
+    }
+
+    @GetMapping("/mood")
+    fun getMoodPreferences(
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<MoodPreferenceResponse>> {
+        val moodTypes = preferenceService.getMoodPreferences(member)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "분위기 취향을 성공적으로 조회했습니다.",
+                data = MoodPreferenceResponse(moodTypes)
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/PreferenceService.kt
+++ b/src/main/kotlin/com/example/mykku/preference/PreferenceService.kt
@@ -1,0 +1,52 @@
+package com.example.mykku.preference
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.tool.*
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PreferenceService(
+    private val genrePreferenceReader: GenrePreferenceReader,
+    private val genrePreferenceWriter: GenrePreferenceWriter,
+    private val goodsPreferenceReader: GoodsPreferenceReader,
+    private val goodsPreferenceWriter: GoodsPreferenceWriter,
+    private val moodPreferenceReader: MoodPreferenceReader,
+    private val moodPreferenceWriter: MoodPreferenceWriter
+) {
+    @Transactional
+    fun updateGenrePreferences(member: Member, genreTypes: List<GenreType>) {
+        genrePreferenceWriter.replacePreferences(member, genreTypes)
+    }
+
+    @Transactional
+    fun updateGoodsPreferences(member: Member, goodsTypes: List<GoodsType>) {
+        goodsPreferenceWriter.replacePreferences(member, goodsTypes)
+    }
+
+    @Transactional
+    fun updateMoodPreferences(member: Member, moodTypes: List<MoodType>) {
+        moodPreferenceWriter.replacePreferences(member, moodTypes)
+    }
+
+    @Transactional(readOnly = true)
+    fun getGenrePreferences(member: Member): List<GenreType> {
+        return genrePreferenceReader.findByMember(member)
+            .map { it.genreType }
+    }
+
+    @Transactional(readOnly = true)
+    fun getGoodsPreferences(member: Member): List<GoodsType> {
+        return goodsPreferenceReader.findByMember(member)
+            .map { it.goodsType }
+    }
+
+    @Transactional(readOnly = true)
+    fun getMoodPreferences(member: Member): List<MoodType> {
+        return moodPreferenceReader.findByMember(member)
+            .map { it.moodType }
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/domain/GenreType.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/GenreType.kt
@@ -1,0 +1,11 @@
+package com.example.mykku.preference.domain
+
+enum class GenreType(val displayName: String) {
+    KPOP("케이팝"),
+    WEBTOON_WEBNOVEL("웹소설/웹툰"),
+    MANGA_ANIME("만화/애니메이션"),
+    GAME_ESPORTS("게임/E-sports"),
+    DRAMA_MOVIE("드라마/영화"),
+    THEATER_MUSICAL("연극/뮤지컬"),
+    BAND_ROCK("밴드/락")
+}

--- a/src/main/kotlin/com/example/mykku/preference/domain/GoodsType.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/GoodsType.kt
@@ -1,0 +1,12 @@
+package com.example.mykku.preference.domain
+
+enum class GoodsType(val displayName: String) {
+    PHOTOCARD_HOLDER("포토카드 홀더/탑로더"),
+    DESK_TERIOR("데스크테리어"),
+    LIGHT_STICK_DECO("응원봉 꾸미기"),
+    ITABAG("이타백"),
+    UCHIWA("우치와"),
+    DIARY_DECO("다이어리 꾸미기"),
+    NAME_BOARD("네임보드"),
+    PHONE_ACCESSORY("핸드폰 악세서리")
+}

--- a/src/main/kotlin/com/example/mykku/preference/domain/MemberGenrePreference.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/MemberGenrePreference.kt
@@ -1,0 +1,21 @@
+package com.example.mykku.preference.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.member.domain.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "member_genre_preference")
+class MemberGenrePreference(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre_type", nullable = false, length = 50)
+    val genreType: GenreType
+) : BaseEntity()

--- a/src/main/kotlin/com/example/mykku/preference/domain/MemberGoodsPreference.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/MemberGoodsPreference.kt
@@ -1,0 +1,21 @@
+package com.example.mykku.preference.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.member.domain.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "member_goods_preference")
+class MemberGoodsPreference(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "goods_type", nullable = false, length = 50)
+    val goodsType: GoodsType
+) : BaseEntity()

--- a/src/main/kotlin/com/example/mykku/preference/domain/MemberMoodPreference.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/MemberMoodPreference.kt
@@ -1,0 +1,21 @@
+package com.example.mykku.preference.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.member.domain.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "member_mood_preference")
+class MemberMoodPreference(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mood_type", nullable = false, length = 50)
+    val moodType: MoodType
+) : BaseEntity()

--- a/src/main/kotlin/com/example/mykku/preference/domain/MoodType.kt
+++ b/src/main/kotlin/com/example/mykku/preference/domain/MoodType.kt
@@ -1,0 +1,12 @@
+package com.example.mykku.preference.domain
+
+enum class MoodType(val displayName: String) {
+    COZY("포근한/코지한"),
+    KITSCH("키치한"),
+    FRESH("청량한"),
+    DECADENT("퇴폐적인"),
+    SILLY("멍청한"),
+    Y2K("쇠맛/Y2K"),
+    PIXEL_ART("픽셀아트"),
+    FUNNY("웃긴")
+}

--- a/src/main/kotlin/com/example/mykku/preference/dto/GenrePreferenceResponse.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/GenrePreferenceResponse.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.GenreType
+
+data class GenrePreferenceResponse(
+    val genreTypes: List<GenreType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/dto/GoodsPreferenceResponse.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/GoodsPreferenceResponse.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.GoodsType
+
+data class GoodsPreferenceResponse(
+    val goodsTypes: List<GoodsType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/dto/MoodPreferenceResponse.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/MoodPreferenceResponse.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.MoodType
+
+data class MoodPreferenceResponse(
+    val moodTypes: List<MoodType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/dto/UpdateGenrePreferenceRequest.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/UpdateGenrePreferenceRequest.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.GenreType
+
+data class UpdateGenrePreferenceRequest(
+    val genreTypes: List<GenreType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/dto/UpdateGoodsPreferenceRequest.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/UpdateGoodsPreferenceRequest.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.GoodsType
+
+data class UpdateGoodsPreferenceRequest(
+    val goodsTypes: List<GoodsType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/dto/UpdateMoodPreferenceRequest.kt
+++ b/src/main/kotlin/com/example/mykku/preference/dto/UpdateMoodPreferenceRequest.kt
@@ -1,0 +1,7 @@
+package com.example.mykku.preference.dto
+
+import com.example.mykku.preference.domain.MoodType
+
+data class UpdateMoodPreferenceRequest(
+    val moodTypes: List<MoodType>
+)

--- a/src/main/kotlin/com/example/mykku/preference/exception/PreferenceErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/preference/exception/PreferenceErrorCode.kt
@@ -1,0 +1,14 @@
+package com.example.mykku.preference.exception
+
+import com.example.mykku.common.exception.DomainErrorCode
+import org.springframework.http.HttpStatus
+
+enum class PreferenceErrorCode(
+    override val status: HttpStatus,
+    override val message: String
+) : DomainErrorCode {
+    INVALID_GENRE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 장르입니다"),
+    INVALID_GOODS_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 굿즈입니다"),
+    INVALID_MOOD_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 분위기입니다"),
+    EMPTY_PREFERENCE_LIST(HttpStatus.BAD_REQUEST, "취향 목록이 비어있습니다")
+}

--- a/src/main/kotlin/com/example/mykku/preference/exception/PreferenceException.kt
+++ b/src/main/kotlin/com/example/mykku/preference/exception/PreferenceException.kt
@@ -1,0 +1,14 @@
+package com.example.mykku.preference.exception
+
+import com.example.mykku.common.exception.BaseDomainException
+
+class PreferenceException(
+    errorCode: PreferenceErrorCode
+) : BaseDomainException(errorCode) {
+    companion object {
+        fun invalidGenreType() = PreferenceException(PreferenceErrorCode.INVALID_GENRE_TYPE)
+        fun invalidGoodsType() = PreferenceException(PreferenceErrorCode.INVALID_GOODS_TYPE)
+        fun invalidMoodType() = PreferenceException(PreferenceErrorCode.INVALID_MOOD_TYPE)
+        fun emptyPreferenceList() = PreferenceException(PreferenceErrorCode.EMPTY_PREFERENCE_LIST)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/exception/PreferenceExceptionHandler.kt
+++ b/src/main/kotlin/com/example/mykku/preference/exception/PreferenceExceptionHandler.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.preference.exception
+
+import com.example.mykku.common.exception.ErrorResponse
+import com.example.mykku.common.exception.ExceptionLoggingSupport
+import org.slf4j.LoggerFactory
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class PreferenceExceptionHandler {
+
+    private val logger = LoggerFactory.getLogger(PreferenceExceptionHandler::class.java)
+
+    @ExceptionHandler(PreferenceException::class)
+    fun handlePreferenceException(exception: PreferenceException): ResponseEntity<ErrorResponse> {
+        ExceptionLoggingSupport.logException(logger, exception)
+
+        return ResponseEntity
+            .status(exception.errorCode.status)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(ErrorResponse(exception.errorCode.message))
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/repository/MemberGenrePreferenceRepository.kt
+++ b/src/main/kotlin/com/example/mykku/preference/repository/MemberGenrePreferenceRepository.kt
@@ -1,0 +1,14 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.MemberGenrePreference
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberGenrePreferenceRepository : JpaRepository<MemberGenrePreference, Long> {
+    fun findByMember(member: Member): List<MemberGenrePreference>
+    fun deleteByMember(member: Member)
+    fun existsByMemberAndGenreType(member: Member, genreType: GenreType): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/preference/repository/MemberGoodsPreferenceRepository.kt
+++ b/src/main/kotlin/com/example/mykku/preference/repository/MemberGoodsPreferenceRepository.kt
@@ -1,0 +1,14 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberGoodsPreferenceRepository : JpaRepository<MemberGoodsPreference, Long> {
+    fun findByMember(member: Member): List<MemberGoodsPreference>
+    fun deleteByMember(member: Member)
+    fun existsByMemberAndGoodsType(member: Member, goodsType: GoodsType): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/preference/repository/MemberMoodPreferenceRepository.kt
+++ b/src/main/kotlin/com/example/mykku/preference/repository/MemberMoodPreferenceRepository.kt
@@ -1,0 +1,14 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.domain.MoodType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberMoodPreferenceRepository : JpaRepository<MemberMoodPreference, Long> {
+    fun findByMember(member: Member): List<MemberMoodPreference>
+    fun deleteByMember(member: Member)
+    fun existsByMemberAndMoodType(member: Member, moodType: MoodType): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/GenrePreferenceReader.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/GenrePreferenceReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.MemberGenrePreference
+import com.example.mykku.preference.repository.MemberGenrePreferenceRepository
+import org.springframework.stereotype.Component
+
+@Component
+class GenrePreferenceReader(
+    private val memberGenrePreferenceRepository: MemberGenrePreferenceRepository
+) {
+    fun findByMember(member: Member): List<MemberGenrePreference> {
+        return memberGenrePreferenceRepository.findByMember(member)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/GenrePreferenceWriter.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/GenrePreferenceWriter.kt
@@ -1,0 +1,27 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.MemberGenrePreference
+import com.example.mykku.preference.repository.MemberGenrePreferenceRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GenrePreferenceWriter(
+    private val memberGenrePreferenceRepository: MemberGenrePreferenceRepository
+) {
+    @Transactional
+    fun replacePreferences(member: Member, genreTypes: List<GenreType>) {
+        memberGenrePreferenceRepository.deleteByMember(member)
+
+        val preferences = genreTypes.map { genreType ->
+            MemberGenrePreference(
+                member = member,
+                genreType = genreType
+            )
+        }
+
+        memberGenrePreferenceRepository.saveAll(preferences)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/GoodsPreferenceReader.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/GoodsPreferenceReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import com.example.mykku.preference.repository.MemberGoodsPreferenceRepository
+import org.springframework.stereotype.Component
+
+@Component
+class GoodsPreferenceReader(
+    private val memberGoodsPreferenceRepository: MemberGoodsPreferenceRepository
+) {
+    fun findByMember(member: Member): List<MemberGoodsPreference> {
+        return memberGoodsPreferenceRepository.findByMember(member)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/GoodsPreferenceWriter.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/GoodsPreferenceWriter.kt
@@ -1,0 +1,27 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import com.example.mykku.preference.repository.MemberGoodsPreferenceRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GoodsPreferenceWriter(
+    private val memberGoodsPreferenceRepository: MemberGoodsPreferenceRepository
+) {
+    @Transactional
+    fun replacePreferences(member: Member, goodsTypes: List<GoodsType>) {
+        memberGoodsPreferenceRepository.deleteByMember(member)
+
+        val preferences = goodsTypes.map { goodsType ->
+            MemberGoodsPreference(
+                member = member,
+                goodsType = goodsType
+            )
+        }
+
+        memberGoodsPreferenceRepository.saveAll(preferences)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/MoodPreferenceReader.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/MoodPreferenceReader.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.repository.MemberMoodPreferenceRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MoodPreferenceReader(
+    private val memberMoodPreferenceRepository: MemberMoodPreferenceRepository
+) {
+    fun findByMember(member: Member): List<MemberMoodPreference> {
+        return memberMoodPreferenceRepository.findByMember(member)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/preference/tool/MoodPreferenceWriter.kt
+++ b/src/main/kotlin/com/example/mykku/preference/tool/MoodPreferenceWriter.kt
@@ -1,0 +1,27 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.repository.MemberMoodPreferenceRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class MoodPreferenceWriter(
+    private val memberMoodPreferenceRepository: MemberMoodPreferenceRepository
+) {
+    @Transactional
+    fun replacePreferences(member: Member, moodTypes: List<MoodType>) {
+        memberMoodPreferenceRepository.deleteByMember(member)
+
+        val preferences = moodTypes.map { moodType ->
+            MemberMoodPreference(
+                member = member,
+                moodType = moodType
+            )
+        }
+
+        memberMoodPreferenceRepository.saveAll(preferences)
+    }
+}

--- a/src/main/resources/db/migration/V3__add_preference_tables.sql
+++ b/src/main/resources/db/migration/V3__add_preference_tables.sql
@@ -1,0 +1,37 @@
+-- 장르 취향 테이블
+CREATE TABLE member_genre_preference (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id VARCHAR(255) NOT NULL,
+    genre_type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_genre_preference_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    CONSTRAINT uk_genre_preference_member_type UNIQUE (member_id, genre_type)
+);
+
+-- 굿즈 취향 테이블
+CREATE TABLE member_goods_preference (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id VARCHAR(255) NOT NULL,
+    goods_type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_goods_preference_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    CONSTRAINT uk_goods_preference_member_type UNIQUE (member_id, goods_type)
+);
+
+-- 분위기 취향 테이블
+CREATE TABLE member_mood_preference (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id VARCHAR(255) NOT NULL,
+    mood_type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_mood_preference_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    CONSTRAINT uk_mood_preference_member_type UNIQUE (member_id, mood_type)
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_genre_preference_member ON member_genre_preference(member_id);
+CREATE INDEX idx_goods_preference_member ON member_goods_preference(member_id);
+CREATE INDEX idx_mood_preference_member ON member_mood_preference(member_id);

--- a/src/test/kotlin/com/example/mykku/docs/PreferenceControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/PreferenceControllerRestDocsTest.kt
@@ -62,7 +62,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                     ),
                     requestFields(
                         fieldWithPath("genreTypes").type(JsonFieldType.ARRAY)
-                            .description("장르 취향 목록 (KPOP, WEBTOON_WEBNOVEL, MANGA_ANIME, GAME_ESPORTS, DRAMA_MOVIE, THEATER_MUSICAL, BAND_ROCK)")
+                            .description("장르 취향 목록 (${GenreType.entries.joinToString { it.name }})")
                     ),
                     responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -99,7 +99,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                         fieldWithPath("data.genreTypes").type(JsonFieldType.ARRAY)
-                            .description("장르 취향 목록 (KPOP, WEBTOON_WEBNOVEL, MANGA_ANIME, GAME_ESPORTS, DRAMA_MOVIE, THEATER_MUSICAL, BAND_ROCK)")
+                            .description("장르 취향 목록 (${GenreType.entries.joinToString { it.name }}")
                     )
                 )
             )
@@ -130,7 +130,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                     ),
                     requestFields(
                         fieldWithPath("goodsTypes").type(JsonFieldType.ARRAY)
-                            .description("굿즈 취향 목록 (ITABAG, PHOTOCARD_HOLDER, UCHIWA, NAME_BOARD, DESK_TERIOR, LED_SIGN, SLOGAN, CUSHION)")
+                            .description("굿즈 취향 목록 (${GoodsType.entries.joinToString { it.name }})")
                     ),
                     responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -167,7 +167,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                         fieldWithPath("data.goodsTypes").type(JsonFieldType.ARRAY)
-                            .description("굿즈 취향 목록 (ITABAG, PHOTOCARD_HOLDER, UCHIWA, NAME_BOARD, DESK_TERIOR, LED_SIGN, SLOGAN, CUSHION)")
+                            .description("굿즈 취향 목록 (${GoodsType.entries.joinToString { it.name }})")
                     )
                 )
             )
@@ -198,7 +198,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                     ),
                     requestFields(
                         fieldWithPath("moodTypes").type(JsonFieldType.ARRAY)
-                            .description("분위기 취향 목록 (COZY, MINIMALIST, KITSCH, FRESH, DANDY, SPORTY, Y2K, STREET)")
+                            .description("분위기 취향 목록 (${MoodType.entries.joinToString { it.name }})")
                     ),
                     responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -235,7 +235,7 @@ class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                         fieldWithPath("data.moodTypes").type(JsonFieldType.ARRAY)
-                            .description("분위기 취향 목록 (COZY, MINIMALIST, KITSCH, FRESH, DANDY, SPORTY, Y2K, STREET)")
+                            .description("분위기 취향 목록 (${MoodType.entries.joinToString { it.name }})")
                     )
                 )
             )

--- a/src/test/kotlin/com/example/mykku/docs/PreferenceControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/PreferenceControllerRestDocsTest.kt
@@ -1,0 +1,243 @@
+package com.example.mykku.docs
+
+import com.example.mykku.BaseControllerRestDocsTest
+import com.example.mykku.preference.PreferenceController
+import com.example.mykku.preference.PreferenceService
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.dto.*
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.http.MediaType
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+class PreferenceControllerRestDocsTest : BaseControllerRestDocsTest() {
+
+    @Mock
+    private lateinit var preferenceService: PreferenceService
+
+    @InjectMocks
+    private lateinit var preferenceController: PreferenceController
+
+    override fun createMockMvcBuilder(): StandaloneMockMvcBuilder {
+        return MockMvcBuilders.standaloneSetup(preferenceController)
+    }
+
+    @Test
+    fun `장르 취향 저장 API 문서화`() {
+        // given
+        val request = UpdateGenrePreferenceRequest(
+            genreTypes = listOf(GenreType.KPOP, GenreType.BAND_ROCK, GenreType.GAME_ESPORTS)
+        )
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.post("/api/v1/preferences/genre")
+                .header("Authorization", "Bearer jwt-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("장르 취향이 성공적으로 저장되었습니다."))
+            .andDo(
+                document(
+                    "preference-genre-update",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    requestFields(
+                        fieldWithPath("genreTypes").type(JsonFieldType.ARRAY)
+                            .description("장르 취향 목록 (KPOP, WEBTOON_WEBNOVEL, MANGA_ANIME, GAME_ESPORTS, DRAMA_MOVIE, THEATER_MUSICAL, BAND_ROCK)")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터 (없음)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `장르 취향 조회 API 문서화`() {
+        // given
+        val response = GenrePreferenceResponse(
+            genreTypes = listOf(GenreType.KPOP, GenreType.BAND_ROCK)
+        )
+
+        `when`(preferenceService.getGenrePreferences(any())).thenReturn(response.genreTypes)
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/preferences/genre")
+                .header("Authorization", "Bearer jwt-token")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("장르 취향을 성공적으로 조회했습니다."))
+            .andDo(
+                document(
+                    "preference-genre-get",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.genreTypes").type(JsonFieldType.ARRAY)
+                            .description("장르 취향 목록 (KPOP, WEBTOON_WEBNOVEL, MANGA_ANIME, GAME_ESPORTS, DRAMA_MOVIE, THEATER_MUSICAL, BAND_ROCK)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `굿즈 취향 저장 API 문서화`() {
+        // given
+        val request = UpdateGoodsPreferenceRequest(
+            goodsTypes = listOf(GoodsType.ITABAG, GoodsType.PHOTOCARD_HOLDER)
+        )
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.post("/api/v1/preferences/goods")
+                .header("Authorization", "Bearer jwt-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("굿즈 취향이 성공적으로 저장되었습니다."))
+            .andDo(
+                document(
+                    "preference-goods-update",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    requestFields(
+                        fieldWithPath("goodsTypes").type(JsonFieldType.ARRAY)
+                            .description("굿즈 취향 목록 (ITABAG, PHOTOCARD_HOLDER, UCHIWA, NAME_BOARD, DESK_TERIOR, LED_SIGN, SLOGAN, CUSHION)")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터 (없음)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `굿즈 취향 조회 API 문서화`() {
+        // given
+        val response = GoodsPreferenceResponse(
+            goodsTypes = listOf(GoodsType.PHOTOCARD_HOLDER, GoodsType.UCHIWA)
+        )
+
+        `when`(preferenceService.getGoodsPreferences(any())).thenReturn(response.goodsTypes)
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/preferences/goods")
+                .header("Authorization", "Bearer jwt-token")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("굿즈 취향을 성공적으로 조회했습니다."))
+            .andDo(
+                document(
+                    "preference-goods-get",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.goodsTypes").type(JsonFieldType.ARRAY)
+                            .description("굿즈 취향 목록 (ITABAG, PHOTOCARD_HOLDER, UCHIWA, NAME_BOARD, DESK_TERIOR, LED_SIGN, SLOGAN, CUSHION)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `분위기 취향 저장 API 문서화`() {
+        // given
+        val request = UpdateMoodPreferenceRequest(
+            moodTypes = listOf(MoodType.COZY, MoodType.FRESH)
+        )
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.post("/api/v1/preferences/mood")
+                .header("Authorization", "Bearer jwt-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("분위기 취향이 성공적으로 저장되었습니다."))
+            .andDo(
+                document(
+                    "preference-mood-update",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    requestFields(
+                        fieldWithPath("moodTypes").type(JsonFieldType.ARRAY)
+                            .description("분위기 취향 목록 (COZY, MINIMALIST, KITSCH, FRESH, DANDY, SPORTY, Y2K, STREET)")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터 (없음)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `분위기 취향 조회 API 문서화`() {
+        // given
+        val response = MoodPreferenceResponse(
+            moodTypes = listOf(MoodType.KITSCH, MoodType.Y2K)
+        )
+
+        `when`(preferenceService.getMoodPreferences(any())).thenReturn(response.moodTypes)
+
+        // when & then
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/preferences/mood")
+                .header("Authorization", "Bearer jwt-token")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("분위기 취향을 성공적으로 조회했습니다."))
+            .andDo(
+                document(
+                    "preference-mood-get",
+                    requestHeaders(
+                        headerWithName("Authorization").description("JWT 인증 토큰 (Bearer {token})")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.moodTypes").type(JsonFieldType.ARRAY)
+                            .description("분위기 취향 목록 (COZY, MINIMALIST, KITSCH, FRESH, DANDY, SPORTY, Y2K, STREET)")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/PreferenceControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/PreferenceControllerTest.kt
@@ -1,0 +1,189 @@
+package com.example.mykku.preference
+
+import com.example.mykku.BaseControllerTest
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.dto.UpdateGenrePreferenceRequest
+import com.example.mykku.preference.dto.UpdateGoodsPreferenceRequest
+import com.example.mykku.preference.dto.UpdateMoodPreferenceRequest
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("PreferenceController 통합 테스트")
+class PreferenceControllerTest : BaseControllerTest() {
+
+    @Test
+    @DisplayName("장르 취향 저장 - 정상 케이스")
+    fun `updateGenrePreferences - 정상적으로 장르 취향을 저장한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+        val request = UpdateGenrePreferenceRequest(
+            genreTypes = listOf(GenreType.KPOP, GenreType.BAND_ROCK)
+        )
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/preferences/genre")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("장르 취향이 성공적으로 저장되었습니다."))
+    }
+
+    @Test
+    @DisplayName("장르 취향 조회 - 정상 케이스")
+    fun `getGenrePreferences - 장르 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+
+        // 먼저 취향 저장
+        val request = UpdateGenrePreferenceRequest(
+            genreTypes = listOf(GenreType.KPOP, GenreType.GAME_ESPORTS)
+        )
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+            .post("/api/v1/preferences/genre")
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+        .`when`()
+            .get("/api/v1/preferences/genre")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("장르 취향을 성공적으로 조회했습니다."))
+            .body("data.genreTypes", hasSize<Any>(2))
+            .body("data.genreTypes", hasItems("KPOP", "GAME_ESPORTS"))
+    }
+
+    @Test
+    @DisplayName("굿즈 취향 저장 - 정상 케이스")
+    fun `updateGoodsPreferences - 정상적으로 굿즈 취향을 저장한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+        val request = UpdateGoodsPreferenceRequest(
+            goodsTypes = listOf(GoodsType.ITABAG, GoodsType.DESK_TERIOR)
+        )
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/preferences/goods")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("굿즈 취향이 성공적으로 저장되었습니다."))
+    }
+
+    @Test
+    @DisplayName("굿즈 취향 조회 - 정상 케이스")
+    fun `getGoodsPreferences - 굿즈 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+
+        // 먼저 취향 저장
+        val request = UpdateGoodsPreferenceRequest(
+            goodsTypes = listOf(GoodsType.PHOTOCARD_HOLDER, GoodsType.NAME_BOARD)
+        )
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+            .post("/api/v1/preferences/goods")
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+        .`when`()
+            .get("/api/v1/preferences/goods")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("굿즈 취향을 성공적으로 조회했습니다."))
+            .body("data.goodsTypes", hasSize<Any>(2))
+            .body("data.goodsTypes", hasItems("PHOTOCARD_HOLDER", "NAME_BOARD"))
+    }
+
+    @Test
+    @DisplayName("분위기 취향 저장 - 정상 케이스")
+    fun `updateMoodPreferences - 정상적으로 분위기 취향을 저장한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+        val request = UpdateMoodPreferenceRequest(
+            moodTypes = listOf(MoodType.COZY, MoodType.KITSCH)
+        )
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/preferences/mood")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("분위기 취향이 성공적으로 저장되었습니다."))
+    }
+
+    @Test
+    @DisplayName("분위기 취향 조회 - 정상 케이스")
+    fun `getMoodPreferences - 분위기 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember(id = "member1")
+        val authHeader = getBearerToken("member1")
+
+        // 먼저 취향 저장
+        val request = UpdateMoodPreferenceRequest(
+            moodTypes = listOf(MoodType.FRESH, MoodType.Y2K)
+        )
+        RestAssured.given()
+            .header("Authorization", authHeader)
+            .contentType(ContentType.JSON)
+            .body(request)
+            .post("/api/v1/preferences/mood")
+
+        // when & then
+        RestAssured.given()
+            .header("Authorization", authHeader)
+        .`when`()
+            .get("/api/v1/preferences/mood")
+        .then()
+            .statusCode(200)
+            .body("message", equalTo("분위기 취향을 성공적으로 조회했습니다."))
+            .body("data.moodTypes", hasSize<Any>(2))
+            .body("data.moodTypes", hasItems("FRESH", "Y2K"))
+    }
+
+    @Test
+    @DisplayName("취향 저장 - 인증되지 않은 사용자")
+    fun `updatePreferences - 인증되지 않은 사용자는 취향을 저장할 수 없다`() {
+        // given
+        val request = UpdateGenrePreferenceRequest(
+            genreTypes = listOf(GenreType.KPOP)
+        )
+
+        // when & then
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(request)
+        .`when`()
+            .post("/api/v1/preferences/genre")
+        .then()
+            .statusCode(401)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/PreferenceServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/PreferenceServiceTest.kt
@@ -1,0 +1,140 @@
+package com.example.mykku.preference
+
+import com.example.mykku.BaseServiceTest
+import com.example.mykku.preference.domain.*
+import com.example.mykku.preference.tool.*
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class PreferenceServiceTest : BaseServiceTest() {
+
+    @Mock
+    private lateinit var genrePreferenceReader: GenrePreferenceReader
+
+    @Mock
+    private lateinit var genrePreferenceWriter: GenrePreferenceWriter
+
+    @Mock
+    private lateinit var goodsPreferenceReader: GoodsPreferenceReader
+
+    @Mock
+    private lateinit var goodsPreferenceWriter: GoodsPreferenceWriter
+
+    @Mock
+    private lateinit var moodPreferenceReader: MoodPreferenceReader
+
+    @Mock
+    private lateinit var moodPreferenceWriter: MoodPreferenceWriter
+
+    @InjectMocks
+    private lateinit var preferenceService: PreferenceService
+
+    @Test
+    fun `updateGenrePreferences는 장르 취향을 업데이트한다`() {
+        // given
+        val member = createTestMember()
+        val genreTypes = listOf(GenreType.KPOP, GenreType.BAND_ROCK)
+
+        // when
+        preferenceService.updateGenrePreferences(member, genreTypes)
+
+        // then
+        verify(genrePreferenceWriter).replacePreferences(member, genreTypes)
+    }
+
+    @Test
+    fun `getGenrePreferences는 장르 취향 목록을 반환한다`() {
+        // given
+        val member = createTestMember()
+        val preferences = listOf(
+            MemberGenrePreference(id = 1L, member = member, genreType = GenreType.KPOP),
+            MemberGenrePreference(id = 2L, member = member, genreType = GenreType.GAME_ESPORTS)
+        )
+
+        whenever(genrePreferenceReader.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = preferenceService.getGenrePreferences(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertEquals(GenreType.KPOP, result[0])
+        assertEquals(GenreType.GAME_ESPORTS, result[1])
+        verify(genrePreferenceReader).findByMember(member)
+    }
+
+    @Test
+    fun `updateGoodsPreferences는 굿즈 취향을 업데이트한다`() {
+        // given
+        val member = createTestMember()
+        val goodsTypes = listOf(GoodsType.ITABAG, GoodsType.DESK_TERIOR)
+
+        // when
+        preferenceService.updateGoodsPreferences(member, goodsTypes)
+
+        // then
+        verify(goodsPreferenceWriter).replacePreferences(member, goodsTypes)
+    }
+
+    @Test
+    fun `getGoodsPreferences는 굿즈 취향 목록을 반환한다`() {
+        // given
+        val member = createTestMember()
+        val preferences = listOf(
+            MemberGoodsPreference(id = 1L, member = member, goodsType = GoodsType.PHOTOCARD_HOLDER),
+            MemberGoodsPreference(id = 2L, member = member, goodsType = GoodsType.UCHIWA)
+        )
+
+        whenever(goodsPreferenceReader.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = preferenceService.getGoodsPreferences(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertEquals(GoodsType.PHOTOCARD_HOLDER, result[0])
+        assertEquals(GoodsType.UCHIWA, result[1])
+        verify(goodsPreferenceReader).findByMember(member)
+    }
+
+    @Test
+    fun `updateMoodPreferences는 분위기 취향을 업데이트한다`() {
+        // given
+        val member = createTestMember()
+        val moodTypes = listOf(MoodType.COZY, MoodType.FRESH)
+
+        // when
+        preferenceService.updateMoodPreferences(member, moodTypes)
+
+        // then
+        verify(moodPreferenceWriter).replacePreferences(member, moodTypes)
+    }
+
+    @Test
+    fun `getMoodPreferences는 분위기 취향 목록을 반환한다`() {
+        // given
+        val member = createTestMember()
+        val preferences = listOf(
+            MemberMoodPreference(id = 1L, member = member, moodType = MoodType.KITSCH),
+            MemberMoodPreference(id = 2L, member = member, moodType = MoodType.Y2K)
+        )
+
+        whenever(moodPreferenceReader.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = preferenceService.getMoodPreferences(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertEquals(MoodType.KITSCH, result[0])
+        assertEquals(MoodType.Y2K, result[1])
+        verify(moodPreferenceReader).findByMember(member)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/repository/MemberGenrePreferenceRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/repository/MemberGenrePreferenceRepositoryTest.kt
@@ -1,0 +1,104 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.BaseRepositoryTest
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.MemberGenrePreference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+@DisplayName("MemberGenrePreferenceRepository 테스트")
+class MemberGenrePreferenceRepositoryTest : BaseRepositoryTest() {
+
+    @Autowired
+    private lateinit var memberGenrePreferenceRepository: MemberGenrePreferenceRepository
+
+    @Autowired
+    private lateinit var testEntityManager: TestEntityManager
+
+    @Test
+    @DisplayName("장르 취향을 저장하고 조회한다")
+    fun `장르 취향을 저장하고 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberGenrePreference(
+            member = member,
+            genreType = GenreType.KPOP
+        )
+
+        // when
+        val savedPreference = memberGenrePreferenceRepository.save(preference)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        val foundPreference = memberGenrePreferenceRepository.findById(savedPreference.id).orElse(null)
+
+        // then
+        assertThat(foundPreference).isNotNull
+        assertThat(foundPreference.genreType).isEqualTo(GenreType.KPOP)
+        assertThat(foundPreference.member.id).isEqualTo(member.id)
+    }
+
+    @Test
+    @DisplayName("회원의 모든 장르 취향을 조회한다")
+    fun `회원의 모든 장르 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberGenrePreference(member = member, genreType = GenreType.KPOP)
+        val preference2 = MemberGenrePreference(member = member, genreType = GenreType.GAME_ESPORTS)
+        val preference3 = MemberGenrePreference(member = member, genreType = GenreType.DRAMA_MOVIE)
+
+        memberGenrePreferenceRepository.saveAll(listOf(preference1, preference2, preference3))
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val preferences = memberGenrePreferenceRepository.findByMember(member)
+
+        // then
+        assertThat(preferences).hasSize(3)
+        assertThat(preferences.map { it.genreType })
+            .containsExactlyInAnyOrder(GenreType.KPOP, GenreType.GAME_ESPORTS, GenreType.DRAMA_MOVIE)
+    }
+
+    @Test
+    @DisplayName("회원의 장르 취향을 모두 삭제한다")
+    fun `회원의 장르 취향을 모두 삭제한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberGenrePreference(member = member, genreType = GenreType.KPOP)
+        val preference2 = MemberGenrePreference(member = member, genreType = GenreType.BAND_ROCK)
+
+        memberGenrePreferenceRepository.saveAll(listOf(preference1, preference2))
+        testEntityManager.flush()
+
+        // when
+        memberGenrePreferenceRepository.deleteByMember(member)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // then
+        val preferences = memberGenrePreferenceRepository.findByMember(member)
+        assertThat(preferences).isEmpty()
+    }
+
+    @Test
+    @DisplayName("회원과 장르 타입으로 존재 여부를 확인한다")
+    fun `회원과 장르 타입으로 존재 여부를 확인한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberGenrePreference(member = member, genreType = GenreType.MANGA_ANIME)
+        memberGenrePreferenceRepository.save(preference)
+        testEntityManager.flush()
+
+        // when
+        val exists = memberGenrePreferenceRepository.existsByMemberAndGenreType(member, GenreType.MANGA_ANIME)
+        val notExists = memberGenrePreferenceRepository.existsByMemberAndGenreType(member, GenreType.KPOP)
+
+        // then
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/repository/MemberGoodsPreferenceRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/repository/MemberGoodsPreferenceRepositoryTest.kt
@@ -1,0 +1,104 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.BaseRepositoryTest
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+@DisplayName("MemberGoodsPreferenceRepository 테스트")
+class MemberGoodsPreferenceRepositoryTest : BaseRepositoryTest() {
+
+    @Autowired
+    private lateinit var memberGoodsPreferenceRepository: MemberGoodsPreferenceRepository
+
+    @Autowired
+    private lateinit var testEntityManager: TestEntityManager
+
+    @Test
+    @DisplayName("굿즈 취향을 저장하고 조회한다")
+    fun `굿즈 취향을 저장하고 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberGoodsPreference(
+            member = member,
+            goodsType = GoodsType.PHOTOCARD_HOLDER
+        )
+
+        // when
+        val savedPreference = memberGoodsPreferenceRepository.save(preference)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        val foundPreference = memberGoodsPreferenceRepository.findById(savedPreference.id).orElse(null)
+
+        // then
+        assertThat(foundPreference).isNotNull
+        assertThat(foundPreference.goodsType).isEqualTo(GoodsType.PHOTOCARD_HOLDER)
+        assertThat(foundPreference.member.id).isEqualTo(member.id)
+    }
+
+    @Test
+    @DisplayName("회원의 모든 굿즈 취향을 조회한다")
+    fun `회원의 모든 굿즈 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberGoodsPreference(member = member, goodsType = GoodsType.ITABAG)
+        val preference2 = MemberGoodsPreference(member = member, goodsType = GoodsType.DESK_TERIOR)
+        val preference3 = MemberGoodsPreference(member = member, goodsType = GoodsType.NAME_BOARD)
+
+        memberGoodsPreferenceRepository.saveAll(listOf(preference1, preference2, preference3))
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val preferences = memberGoodsPreferenceRepository.findByMember(member)
+
+        // then
+        assertThat(preferences).hasSize(3)
+        assertThat(preferences.map { it.goodsType })
+            .containsExactlyInAnyOrder(GoodsType.ITABAG, GoodsType.DESK_TERIOR, GoodsType.NAME_BOARD)
+    }
+
+    @Test
+    @DisplayName("회원의 굿즈 취향을 모두 삭제한다")
+    fun `회원의 굿즈 취향을 모두 삭제한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberGoodsPreference(member = member, goodsType = GoodsType.UCHIWA)
+        val preference2 = MemberGoodsPreference(member = member, goodsType = GoodsType.DIARY_DECO)
+
+        memberGoodsPreferenceRepository.saveAll(listOf(preference1, preference2))
+        testEntityManager.flush()
+
+        // when
+        memberGoodsPreferenceRepository.deleteByMember(member)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // then
+        val preferences = memberGoodsPreferenceRepository.findByMember(member)
+        assertThat(preferences).isEmpty()
+    }
+
+    @Test
+    @DisplayName("회원과 굿즈 타입으로 존재 여부를 확인한다")
+    fun `회원과 굿즈 타입으로 존재 여부를 확인한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberGoodsPreference(member = member, goodsType = GoodsType.PHONE_ACCESSORY)
+        memberGoodsPreferenceRepository.save(preference)
+        testEntityManager.flush()
+
+        // when
+        val exists = memberGoodsPreferenceRepository.existsByMemberAndGoodsType(member, GoodsType.PHONE_ACCESSORY)
+        val notExists = memberGoodsPreferenceRepository.existsByMemberAndGoodsType(member, GoodsType.ITABAG)
+
+        // then
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/repository/MemberMoodPreferenceRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/repository/MemberMoodPreferenceRepositoryTest.kt
@@ -1,0 +1,104 @@
+package com.example.mykku.preference.repository
+
+import com.example.mykku.BaseRepositoryTest
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.domain.MoodType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+@DisplayName("MemberMoodPreferenceRepository 테스트")
+class MemberMoodPreferenceRepositoryTest : BaseRepositoryTest() {
+
+    @Autowired
+    private lateinit var memberMoodPreferenceRepository: MemberMoodPreferenceRepository
+
+    @Autowired
+    private lateinit var testEntityManager: TestEntityManager
+
+    @Test
+    @DisplayName("분위기 취향을 저장하고 조회한다")
+    fun `분위기 취향을 저장하고 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberMoodPreference(
+            member = member,
+            moodType = MoodType.COZY
+        )
+
+        // when
+        val savedPreference = memberMoodPreferenceRepository.save(preference)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        val foundPreference = memberMoodPreferenceRepository.findById(savedPreference.id).orElse(null)
+
+        // then
+        assertThat(foundPreference).isNotNull
+        assertThat(foundPreference.moodType).isEqualTo(MoodType.COZY)
+        assertThat(foundPreference.member.id).isEqualTo(member.id)
+    }
+
+    @Test
+    @DisplayName("회원의 모든 분위기 취향을 조회한다")
+    fun `회원의 모든 분위기 취향을 조회한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberMoodPreference(member = member, moodType = MoodType.KITSCH)
+        val preference2 = MemberMoodPreference(member = member, moodType = MoodType.FRESH)
+        val preference3 = MemberMoodPreference(member = member, moodType = MoodType.Y2K)
+
+        memberMoodPreferenceRepository.saveAll(listOf(preference1, preference2, preference3))
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // when
+        val preferences = memberMoodPreferenceRepository.findByMember(member)
+
+        // then
+        assertThat(preferences).hasSize(3)
+        assertThat(preferences.map { it.moodType })
+            .containsExactlyInAnyOrder(MoodType.KITSCH, MoodType.FRESH, MoodType.Y2K)
+    }
+
+    @Test
+    @DisplayName("회원의 분위기 취향을 모두 삭제한다")
+    fun `회원의 분위기 취향을 모두 삭제한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference1 = MemberMoodPreference(member = member, moodType = MoodType.DECADENT)
+        val preference2 = MemberMoodPreference(member = member, moodType = MoodType.SILLY)
+
+        memberMoodPreferenceRepository.saveAll(listOf(preference1, preference2))
+        testEntityManager.flush()
+
+        // when
+        memberMoodPreferenceRepository.deleteByMember(member)
+        testEntityManager.flush()
+        testEntityManager.clear()
+
+        // then
+        val preferences = memberMoodPreferenceRepository.findByMember(member)
+        assertThat(preferences).isEmpty()
+    }
+
+    @Test
+    @DisplayName("회원과 분위기 타입으로 존재 여부를 확인한다")
+    fun `회원과 분위기 타입으로 존재 여부를 확인한다`() {
+        // given
+        val member = createAndSaveMember()
+        val preference = MemberMoodPreference(member = member, moodType = MoodType.PIXEL_ART)
+        memberMoodPreferenceRepository.save(preference)
+        testEntityManager.flush()
+
+        // when
+        val exists = memberMoodPreferenceRepository.existsByMemberAndMoodType(member, MoodType.PIXEL_ART)
+        val notExists = memberMoodPreferenceRepository.existsByMemberAndMoodType(member, MoodType.FUNNY)
+
+        // then
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/GenrePreferenceReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/GenrePreferenceReaderTest.kt
@@ -1,0 +1,56 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.MemberGenrePreference
+import com.example.mykku.preference.repository.MemberGenrePreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class GenrePreferenceReaderTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberGenrePreferenceRepository: MemberGenrePreferenceRepository
+
+    @InjectMocks
+    private lateinit var genrePreferenceReader: GenrePreferenceReader
+
+    @Test
+    fun `findByMember는 회원의 모든 장르 취향을 반환한다`() {
+        // given
+        val member = createMockMember()
+        val preferences = listOf(
+            MemberGenrePreference(id = 1L, member = member, genreType = GenreType.KPOP),
+            MemberGenrePreference(id = 2L, member = member, genreType = GenreType.GAME_ESPORTS)
+        )
+
+        whenever(memberGenrePreferenceRepository.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = genrePreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertSame(preferences, result)
+    }
+
+    @Test
+    fun `findByMember는 취향이 없으면 빈 리스트를 반환한다`() {
+        // given
+        val member = createMockMember()
+
+        whenever(memberGenrePreferenceRepository.findByMember(member))
+            .thenReturn(emptyList())
+
+        // when
+        val result = genrePreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(0, result.size)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/GenrePreferenceWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/GenrePreferenceWriterTest.kt
@@ -1,0 +1,36 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.GenreType
+import com.example.mykku.preference.domain.MemberGenrePreference
+import com.example.mykku.preference.repository.MemberGenrePreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class GenrePreferenceWriterTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberGenrePreferenceRepository: MemberGenrePreferenceRepository
+
+    @InjectMocks
+    private lateinit var genrePreferenceWriter: GenrePreferenceWriter
+
+    @Test
+    fun `replacePreferences는 기존 취향을 삭제하고 새 취향을 저장한다`() {
+        // given
+        val member = createMockMember()
+        val genreTypes = listOf(GenreType.KPOP, GenreType.BAND_ROCK)
+
+        // when
+        genrePreferenceWriter.replacePreferences(member, genreTypes)
+
+        // then
+        verify(memberGenrePreferenceRepository).deleteByMember(member)
+        verify(memberGenrePreferenceRepository).saveAll(org.mockito.kotlin.any<List<MemberGenrePreference>>())
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/GoodsPreferenceReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/GoodsPreferenceReaderTest.kt
@@ -1,0 +1,56 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import com.example.mykku.preference.repository.MemberGoodsPreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class GoodsPreferenceReaderTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberGoodsPreferenceRepository: MemberGoodsPreferenceRepository
+
+    @InjectMocks
+    private lateinit var goodsPreferenceReader: GoodsPreferenceReader
+
+    @Test
+    fun `findByMember는 회원의 모든 굿즈 취향을 반환한다`() {
+        // given
+        val member = createMockMember()
+        val preferences = listOf(
+            MemberGoodsPreference(id = 1L, member = member, goodsType = GoodsType.ITABAG),
+            MemberGoodsPreference(id = 2L, member = member, goodsType = GoodsType.DESK_TERIOR)
+        )
+
+        whenever(memberGoodsPreferenceRepository.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = goodsPreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertSame(preferences, result)
+    }
+
+    @Test
+    fun `findByMember는 취향이 없으면 빈 리스트를 반환한다`() {
+        // given
+        val member = createMockMember()
+
+        whenever(memberGoodsPreferenceRepository.findByMember(member))
+            .thenReturn(emptyList())
+
+        // when
+        val result = goodsPreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(0, result.size)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/GoodsPreferenceWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/GoodsPreferenceWriterTest.kt
@@ -1,0 +1,36 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.GoodsType
+import com.example.mykku.preference.domain.MemberGoodsPreference
+import com.example.mykku.preference.repository.MemberGoodsPreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class GoodsPreferenceWriterTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberGoodsPreferenceRepository: MemberGoodsPreferenceRepository
+
+    @InjectMocks
+    private lateinit var goodsPreferenceWriter: GoodsPreferenceWriter
+
+    @Test
+    fun `replacePreferences는 기존 취향을 삭제하고 새 취향을 저장한다`() {
+        // given
+        val member = createMockMember()
+        val goodsTypes = listOf(GoodsType.PHOTOCARD_HOLDER, GoodsType.UCHIWA)
+
+        // when
+        goodsPreferenceWriter.replacePreferences(member, goodsTypes)
+
+        // then
+        verify(memberGoodsPreferenceRepository).deleteByMember(member)
+        verify(memberGoodsPreferenceRepository).saveAll(org.mockito.kotlin.any<List<MemberGoodsPreference>>())
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/MoodPreferenceReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/MoodPreferenceReaderTest.kt
@@ -1,0 +1,56 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.repository.MemberMoodPreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class MoodPreferenceReaderTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberMoodPreferenceRepository: MemberMoodPreferenceRepository
+
+    @InjectMocks
+    private lateinit var moodPreferenceReader: MoodPreferenceReader
+
+    @Test
+    fun `findByMember는 회원의 모든 분위기 취향을 반환한다`() {
+        // given
+        val member = createMockMember()
+        val preferences = listOf(
+            MemberMoodPreference(id = 1L, member = member, moodType = MoodType.COZY),
+            MemberMoodPreference(id = 2L, member = member, moodType = MoodType.KITSCH)
+        )
+
+        whenever(memberMoodPreferenceRepository.findByMember(member))
+            .thenReturn(preferences)
+
+        // when
+        val result = moodPreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(2, result.size)
+        assertSame(preferences, result)
+    }
+
+    @Test
+    fun `findByMember는 취향이 없으면 빈 리스트를 반환한다`() {
+        // given
+        val member = createMockMember()
+
+        whenever(memberMoodPreferenceRepository.findByMember(member))
+            .thenReturn(emptyList())
+
+        // when
+        val result = moodPreferenceReader.findByMember(member)
+
+        // then
+        assertEquals(0, result.size)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/preference/tool/MoodPreferenceWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/preference/tool/MoodPreferenceWriterTest.kt
@@ -1,0 +1,36 @@
+package com.example.mykku.preference.tool
+
+import com.example.mykku.BaseToolTest
+import com.example.mykku.preference.domain.MemberMoodPreference
+import com.example.mykku.preference.domain.MoodType
+import com.example.mykku.preference.repository.MemberMoodPreferenceRepository
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class MoodPreferenceWriterTest : BaseToolTest() {
+
+    @Mock
+    private lateinit var memberMoodPreferenceRepository: MemberMoodPreferenceRepository
+
+    @InjectMocks
+    private lateinit var moodPreferenceWriter: MoodPreferenceWriter
+
+    @Test
+    fun `replacePreferences는 기존 취향을 삭제하고 새 취향을 저장한다`() {
+        // given
+        val member = createMockMember()
+        val moodTypes = listOf(MoodType.FRESH, MoodType.Y2K)
+
+        // when
+        moodPreferenceWriter.replacePreferences(member, moodTypes)
+
+        // then
+        verify(memberMoodPreferenceRepository).deleteByMember(member)
+        verify(memberMoodPreferenceRepository).saveAll(org.mockito.kotlin.any<List<MemberMoodPreference>>())
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 취향 관리 시스템 추가 — 장르, 굿즈, 분위기 선호도 저장 및 조회 기능 제공
* **데이터**
  * 취향 관련 테이블(장르/굿즈/분위기) 추가로 선호도 영구 저장 지원
* **문서화**
  * 취향 API 문서 추가 (파일 내 중복 블록 포함)
* **테스트**
  * API 문서화용 테스트 및 단위·통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->