### PR TITLE
[FEAT] 칭호 기능

### DIFF
--- a/.github/workflows/Dev_CI.yml
+++ b/.github/workflows/Dev_CI.yml
@@ -22,7 +22,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
           MYSQL_DATABASE: mykku_test
         ports:
-          - 3306:3306
+          - 3311:3306
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s

--- a/.github/workflows/Dev_CI.yml
+++ b/.github/workflows/Dev_CI.yml
@@ -18,8 +18,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ""
-          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: mykku_test
         ports:
           - 3311:3306

--- a/docker-coompose.yml
+++ b/docker-coompose.yml
@@ -7,3 +7,12 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
+
+  mysql-test:
+    image: mysql:8.0
+    container_name: mysql-mykku-test
+    environment:
+      MYSQL_DATABASE: mykku_test
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3311:3306"

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -509,6 +509,54 @@ operation::notification-setting-list[snippets='http-request,http-response,respon
 
 operation::notification-setting-update[snippets='http-request,request-fields,http-response,response-fields']
 
+[[role-api]]
+== 칭호 API
+
+=== 내 칭호 목록 조회
+
+사용자가 보유한 칭호 목록을 조회합니다.
+
+operation::role-get-my-roles[snippets='http-request,http-response,response-fields']
+
+=== 대표 칭호 변경
+
+사용자의 대표 칭호를 변경합니다. 보유한 칭호 중에서만 선택할 수 있습니다.
+
+operation::role-change-representative[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[admin-role-api]]
+== 관리자 칭호 API
+
+=== 칭호 목록 조회
+
+모든 칭호 목록을 조회합니다. (관리자 전용)
+
+operation::admin-role-get-all[snippets='http-request,http-response,response-fields']
+
+=== 칭호 생성
+
+새로운 칭호를 생성합니다. (관리자 전용)
+
+operation::admin-role-create[snippets='http-request,request-fields,http-response,response-fields']
+
+=== 칭호 수정
+
+기존 칭호의 이름과 설명을 수정합니다. (관리자 전용)
+
+operation::admin-role-update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+=== 칭호 삭제
+
+칭호를 삭제합니다. 회원이 사용 중인 칭호는 삭제할 수 없습니다. (관리자 전용)
+
+operation::admin-role-delete[snippets='http-request,path-parameters,http-response,response-fields']
+
+=== 회원에게 칭호 부여
+
+특정 회원에게 칭호를 부여합니다. (관리자 전용)
+
+operation::admin-role-assign[snippets='http-request,path-parameters,http-response,response-fields']
+
 [[error-api]]
 == 에러 응답
 

--- a/src/main/kotlin/com/example/mykku/admin/controller/AdminRoleApiController.kt
+++ b/src/main/kotlin/com/example/mykku/admin/controller/AdminRoleApiController.kt
@@ -1,0 +1,83 @@
+package com.example.mykku.admin.controller
+
+import com.example.mykku.admin.service.AdminRoleService
+import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.role.dto.CreateRoleRequest
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.example.mykku.role.dto.RoleResponse
+import com.example.mykku.role.dto.UpdateRoleRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/admin/api/v1/roles")
+class AdminRoleApiController(
+    private val adminRoleService: AdminRoleService
+) {
+    @GetMapping
+    fun getAllRoles(): ResponseEntity<ApiResponse<List<RoleResponse>>> {
+        val roles = adminRoleService.getAllRoles()
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "칭호 목록 조회 성공",
+                data = roles
+            )
+        )
+    }
+
+    @PostMapping
+    fun createRole(
+        @RequestBody @Valid request: CreateRoleRequest
+    ): ResponseEntity<ApiResponse<RoleResponse>> {
+        val role = adminRoleService.createRole(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse(
+                message = "칭호 생성 성공",
+                data = role
+            )
+        )
+    }
+
+    @PutMapping("/{roleId}")
+    fun updateRole(
+        @PathVariable roleId: Long,
+        @RequestBody @Valid request: UpdateRoleRequest
+    ): ResponseEntity<ApiResponse<RoleResponse>> {
+        val role = adminRoleService.updateRole(roleId, request)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "칭호 수정 성공",
+                data = role
+            )
+        )
+    }
+
+    @DeleteMapping("/{roleId}")
+    fun deleteRole(
+        @PathVariable roleId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        adminRoleService.deleteRole(roleId)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "칭호 삭제 성공",
+                data = Unit
+            )
+        )
+    }
+
+    @PostMapping("/{roleId}/members/{memberId}")
+    fun assignRoleToMember(
+        @PathVariable roleId: Long,
+        @PathVariable memberId: String
+    ): ResponseEntity<ApiResponse<MemberRoleResponse>> {
+        val memberRole = adminRoleService.assignRoleToMember(roleId, memberId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse(
+                message = "칭호 부여 성공",
+                data = memberRole
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/admin/service/AdminRoleService.kt
+++ b/src/main/kotlin/com/example/mykku/admin/service/AdminRoleService.kt
@@ -1,0 +1,68 @@
+package com.example.mykku.admin.service
+
+import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.member.tool.MemberReader
+import com.example.mykku.role.dto.CreateRoleRequest
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.example.mykku.role.dto.RoleResponse
+import com.example.mykku.role.dto.UpdateRoleRequest
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.MemberRoleRepository
+import com.example.mykku.role.tool.MemberRoleWriter
+import com.example.mykku.role.tool.RoleReader
+import com.example.mykku.role.tool.RoleWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminRoleService(
+    private val roleReader: RoleReader,
+    private val roleWriter: RoleWriter,
+    private val memberRoleWriter: MemberRoleWriter,
+    private val memberReader: MemberReader,
+    private val memberRepository: MemberRepository,
+    private val memberRoleRepository: MemberRoleRepository
+) {
+    fun getAllRoles(): List<RoleResponse> {
+        val roles = roleReader.getAllRoles()
+        return roles.map { RoleResponse(it) }
+    }
+
+    @Transactional
+    fun createRole(request: CreateRoleRequest): RoleResponse {
+        val role = roleWriter.create(request.name, request.description)
+        return RoleResponse(role)
+    }
+
+    @Transactional
+    fun updateRole(roleId: Long, request: UpdateRoleRequest): RoleResponse {
+        val role = roleReader.getRoleById(roleId)
+        val updatedRole = roleWriter.update(role, request.name, request.description)
+        return RoleResponse(updatedRole)
+    }
+
+    @Transactional
+    fun deleteRole(roleId: Long) {
+        val role = roleReader.getRoleById(roleId)
+
+        if (memberRepository.existsByRole(role)) {
+            throw RoleException.roleInUse()
+        }
+
+        if (memberRoleRepository.existsByRole(role)) {
+            throw RoleException.roleInUse()
+        }
+
+        roleWriter.delete(role)
+    }
+
+    @Transactional
+    fun assignRoleToMember(roleId: Long, memberId: String): MemberRoleResponse {
+        val role = roleReader.getRoleById(roleId)
+        val member = memberReader.getMemberById(memberId)
+
+        val memberRole = memberRoleWriter.assignRole(member, role)
+        return MemberRoleResponse(memberRole, member)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/admin/service/AdminRoleService.kt
+++ b/src/main/kotlin/com/example/mykku/admin/service/AdminRoleService.kt
@@ -1,13 +1,12 @@
 package com.example.mykku.admin.service
 
-import com.example.mykku.member.repository.MemberRepository
 import com.example.mykku.member.tool.MemberReader
 import com.example.mykku.role.dto.CreateRoleRequest
 import com.example.mykku.role.dto.MemberRoleResponse
 import com.example.mykku.role.dto.RoleResponse
 import com.example.mykku.role.dto.UpdateRoleRequest
 import com.example.mykku.role.exception.RoleException
-import com.example.mykku.role.repository.MemberRoleRepository
+import com.example.mykku.role.tool.MemberRoleReader
 import com.example.mykku.role.tool.MemberRoleWriter
 import com.example.mykku.role.tool.RoleReader
 import com.example.mykku.role.tool.RoleWriter
@@ -20,9 +19,8 @@ class AdminRoleService(
     private val roleReader: RoleReader,
     private val roleWriter: RoleWriter,
     private val memberRoleWriter: MemberRoleWriter,
-    private val memberReader: MemberReader,
-    private val memberRepository: MemberRepository,
-    private val memberRoleRepository: MemberRoleRepository
+    private val memberRoleReader: MemberRoleReader,
+    private val memberReader: MemberReader
 ) {
     fun getAllRoles(): List<RoleResponse> {
         val roles = roleReader.getAllRoles()
@@ -46,11 +44,11 @@ class AdminRoleService(
     fun deleteRole(roleId: Long) {
         val role = roleReader.getRoleById(roleId)
 
-        if (memberRepository.existsByRole(role)) {
+        if (memberReader.existsByRole(role)) {
             throw RoleException.roleInUse()
         }
 
-        if (memberRoleRepository.existsByRole(role)) {
+        if (memberRoleReader.existsByRole(role)) {
             throw RoleException.roleInUse()
         }
 

--- a/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
+++ b/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
@@ -3,12 +3,16 @@ package com.example.mykku.auth.tool
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.tool.MemberReader
 import com.example.mykku.member.tool.MemberWriter
+import com.example.mykku.role.tool.MemberRoleWriter
+import com.example.mykku.role.tool.RoleReader
 import org.springframework.stereotype.Component
 
 @Component
 class MemberOrchestrator(
     private val memberReader: MemberReader,
-    private val memberWriter: MemberWriter
+    private val memberWriter: MemberWriter,
+    private val roleReader: RoleReader,
+    private val memberRoleWriter: MemberRoleWriter
 ) {
 
     fun findOrCreate(memberInfo: OAuthMemberInfo): Pair<Member, Boolean> {
@@ -23,16 +27,21 @@ class MemberOrchestrator(
     }
 
     private fun createMember(memberInfo: OAuthMemberInfo): Member {
-        return memberWriter.save(
-            Member(
-                id = memberInfo.memberId,
-                nickname = memberInfo.nickname,
-                role = "USER",
-                profileImage = memberInfo.profileImage,
-                provider = memberInfo.provider,
-                socialId = memberInfo.socialId,
-                email = memberInfo.email
-            )
+        val defaultRole = roleReader.getRoleByName("신입 덕후")
+
+        val member = Member.createSocialMember(
+            id = memberInfo.memberId,
+            nickname = memberInfo.nickname,
+            profileImage = memberInfo.profileImage,
+            provider = memberInfo.provider,
+            socialId = memberInfo.socialId,
+            email = memberInfo.email,
+            defaultRole = defaultRole
         )
+
+        memberWriter.save(member)
+        memberRoleWriter.assignRole(member, defaultRole)
+
+        return member
     }
 }

--- a/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
+++ b/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
@@ -27,8 +27,6 @@ class MemberOrchestrator(
     }
 
     private fun createMember(memberInfo: OAuthMemberInfo): Member {
-        val defaultRole = roleReader.getRoleByName("신입 덕후")
-
         val member = Member.createSocialMember(
             id = memberInfo.memberId,
             nickname = memberInfo.nickname,
@@ -39,8 +37,6 @@ class MemberOrchestrator(
         )
 
         memberWriter.save(member)
-        memberRoleWriter.assignRole(member, defaultRole)
-
         return member
     }
 }

--- a/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
+++ b/src/main/kotlin/com/example/mykku/auth/tool/MemberOrchestrator.kt
@@ -35,8 +35,7 @@ class MemberOrchestrator(
             profileImage = memberInfo.profileImage,
             provider = memberInfo.provider,
             socialId = memberInfo.socialId,
-            email = memberInfo.email,
-            defaultRole = defaultRole
+            email = memberInfo.email
         )
 
         memberWriter.save(member)

--- a/src/main/kotlin/com/example/mykku/email/EmailAuthService.kt
+++ b/src/main/kotlin/com/example/mykku/email/EmailAuthService.kt
@@ -68,18 +68,15 @@ class EmailAuthService(
 
         val encodedPassword = passwordEncoder.encode(password)
         val memberId = UUID.randomUUID().toString()
-        val defaultRole = roleReader.getRoleByName("신입 덕후")
 
         val member = Member.createEmailMember(
             id = memberId,
             email = email,
             password = encodedPassword,
-            nickname = nickname,
-            defaultRole = defaultRole
+            nickname = nickname
         )
 
         memberWriter.save(member)
-        memberRoleWriter.assignRole(member, defaultRole)
 
         return jwtTokenProvider.createLoginResponse(member, email, false)
     }

--- a/src/main/kotlin/com/example/mykku/email/EmailAuthService.kt
+++ b/src/main/kotlin/com/example/mykku/email/EmailAuthService.kt
@@ -10,6 +10,8 @@ import com.example.mykku.email.util.TemporaryPasswordGenerator
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.tool.MemberReader
 import com.example.mykku.member.tool.MemberWriter
+import com.example.mykku.role.tool.MemberRoleWriter
+import com.example.mykku.role.tool.RoleReader
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,7 +24,9 @@ class EmailAuthService(
     private val memberReader: MemberReader,
     private val memberWriter: MemberWriter,
     private val passwordEncoder: PasswordEncoder,
-    private val jwtTokenProvider: JwtTokenProvider
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val roleReader: RoleReader,
+    private val memberRoleWriter: MemberRoleWriter
 ) {
 
     @Transactional
@@ -64,15 +68,18 @@ class EmailAuthService(
 
         val encodedPassword = passwordEncoder.encode(password)
         val memberId = UUID.randomUUID().toString()
+        val defaultRole = roleReader.getRoleByName("신입 덕후")
 
         val member = Member.createEmailMember(
             id = memberId,
             email = email,
             password = encodedPassword,
-            nickname = nickname
+            nickname = nickname,
+            defaultRole = defaultRole
         )
 
         memberWriter.save(member)
+        memberRoleWriter.assignRole(member, defaultRole)
 
         return jwtTokenProvider.createLoginResponse(member, email, false)
     }

--- a/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
@@ -12,6 +12,6 @@ data class AuthorResponse(
         memberId = member.id,
         nickname = member.nickname,
         profileImage = member.profileImage,
-        role = member.role.name,
+        role = member.role?.name ?: "",
     )
 }

--- a/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
+++ b/src/main/kotlin/com/example/mykku/feed/dto/AuthorResponse.kt
@@ -12,6 +12,6 @@ data class AuthorResponse(
         memberId = member.id,
         nickname = member.nickname,
         profileImage = member.profileImage,
-        role = member.role,
+        role = member.role.name,
     )
 }

--- a/src/main/kotlin/com/example/mykku/member/domain/Member.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/Member.kt
@@ -2,6 +2,7 @@ package com.example.mykku.member.domain
 
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.exception.MemberException
+import com.example.mykku.role.domain.Role
 import jakarta.persistence.*
 
 @Entity
@@ -12,8 +13,9 @@ class Member(
     @Column(name = "nickname")
     var nickname: String,
 
-    @Column(name = "role")
-    var role: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    var role: Role,
 
     @Column(name = "profile_image")
     var profileImage: String,
@@ -49,12 +51,13 @@ class Member(
             email: String,
             password: String,
             nickname: String,
+            defaultRole: Role,
             profileImage: String = ""
         ): Member {
             return Member(
                 id = id,
                 nickname = nickname,
-                role = "USER",
+                role = defaultRole,
                 profileImage = profileImage,
                 provider = SocialProvider.EMAIL,
                 socialId = null,
@@ -70,12 +73,13 @@ class Member(
             profileImage: String,
             provider: SocialProvider,
             socialId: String,
-            email: String
+            email: String,
+            defaultRole: Role
         ): Member {
             return Member(
                 id = id,
                 nickname = nickname,
-                role = "USER",
+                role = defaultRole,
                 profileImage = profileImage,
                 provider = provider,
                 socialId = socialId,

--- a/src/main/kotlin/com/example/mykku/member/domain/Member.kt
+++ b/src/main/kotlin/com/example/mykku/member/domain/Member.kt
@@ -14,8 +14,8 @@ class Member(
     var nickname: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "role_id", nullable = false)
-    var role: Role,
+    @JoinColumn(name = "role_id")
+    var role: Role? = null,
 
     @Column(name = "profile_image")
     var profileImage: String,
@@ -51,13 +51,11 @@ class Member(
             email: String,
             password: String,
             nickname: String,
-            defaultRole: Role,
             profileImage: String = ""
         ): Member {
             return Member(
                 id = id,
                 nickname = nickname,
-                role = defaultRole,
                 profileImage = profileImage,
                 provider = SocialProvider.EMAIL,
                 socialId = null,
@@ -73,13 +71,11 @@ class Member(
             profileImage: String,
             provider: SocialProvider,
             socialId: String,
-            email: String,
-            defaultRole: Role
+            email: String
         ): Member {
             return Member(
                 id = id,
                 nickname = nickname,
-                role = defaultRole,
                 profileImage = profileImage,
                 provider = provider,
                 socialId = socialId,

--- a/src/main/kotlin/com/example/mykku/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/mykku/member/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.example.mykku.member.repository
 
 import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.Role
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -9,4 +10,5 @@ interface MemberRepository : JpaRepository<Member, String> {
     fun existsByNickname(nickname: String): Boolean
     fun existsByEmail(email: String): Boolean
     fun findByEmail(email: String): Member?
+    fun existsByRole(role: Role): Boolean
 }

--- a/src/main/kotlin/com/example/mykku/member/tool/MemberReader.kt
+++ b/src/main/kotlin/com/example/mykku/member/tool/MemberReader.kt
@@ -4,6 +4,7 @@ import com.example.mykku.member.domain.Member
 import com.example.mykku.member.exception.MemberException
 import com.example.mykku.member.repository.FollowRepository
 import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.domain.Role
 import org.springframework.stereotype.Component
 import java.util.*
 
@@ -43,5 +44,9 @@ class MemberReader(
         minCommonFollowers: Long = 10
     ): List<Member> {
         return followRepository.findRecommendedMembersByCommonFollowers(memberId, minCommonFollowers)
+    }
+
+    fun existsByRole(role: Role): Boolean {
+        return memberRepository.existsByRole(role)
     }
 }

--- a/src/main/kotlin/com/example/mykku/role/RoleController.kt
+++ b/src/main/kotlin/com/example/mykku/role/RoleController.kt
@@ -1,0 +1,41 @@
+package com.example.mykku.role
+
+import com.example.mykku.auth.config.CurrentMember
+import com.example.mykku.common.dto.ApiResponse
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.dto.MemberRoleResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/roles")
+class RoleController(
+    private val roleService: RoleService
+) {
+    @GetMapping("/me")
+    fun getMyRoles(
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<List<MemberRoleResponse>>> {
+        val roles = roleService.getMyRoles(member)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "내 칭호 목록 조회 성공",
+                data = roles
+            )
+        )
+    }
+
+    @PatchMapping("/{memberRoleId}/representative")
+    fun changeRepresentativeRole(
+        @PathVariable memberRoleId: Long,
+        @CurrentMember member: Member
+    ): ResponseEntity<ApiResponse<Unit>> {
+        roleService.changeRepresentativeRole(member, memberRoleId)
+        return ResponseEntity.ok(
+            ApiResponse(
+                message = "대표 칭호 변경 성공",
+                data = Unit
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/RoleService.kt
+++ b/src/main/kotlin/com/example/mykku/role/RoleService.kt
@@ -1,7 +1,7 @@
 package com.example.mykku.role
 
 import com.example.mykku.member.domain.Member
-import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.member.tool.MemberWriter
 import com.example.mykku.role.dto.MemberRoleResponse
 import com.example.mykku.role.tool.MemberRoleReader
 import org.springframework.stereotype.Service
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class RoleService(
     private val memberRoleReader: MemberRoleReader,
-    private val memberRepository: MemberRepository
+    private val memberWriter: MemberWriter
 ) {
     fun getMyRoles(member: Member): List<MemberRoleResponse> {
         val memberRoles = memberRoleReader.getMemberRolesByMember(member)
@@ -23,6 +23,6 @@ class RoleService(
         val memberRole = memberRoleReader.getMemberRoleById(memberRoleId, member)
 
         member.role = memberRole.role
-        memberRepository.save(member)
+        memberWriter.save(member)
     }
 }

--- a/src/main/kotlin/com/example/mykku/role/RoleService.kt
+++ b/src/main/kotlin/com/example/mykku/role/RoleService.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.role
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.example.mykku.role.tool.MemberRoleReader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class RoleService(
+    private val memberRoleReader: MemberRoleReader,
+    private val memberRepository: MemberRepository
+) {
+    fun getMyRoles(member: Member): List<MemberRoleResponse> {
+        val memberRoles = memberRoleReader.getMemberRolesByMember(member)
+        return memberRoles.map { MemberRoleResponse(it, member) }
+    }
+
+    @Transactional
+    fun changeRepresentativeRole(member: Member, memberRoleId: Long) {
+        val memberRole = memberRoleReader.getMemberRoleById(memberRoleId, member)
+
+        member.role = memberRole.role
+        memberRepository.save(member)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/domain/MemberRole.kt
+++ b/src/main/kotlin/com/example/mykku/role/domain/MemberRole.kt
@@ -1,0 +1,21 @@
+package com.example.mykku.role.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import com.example.mykku.member.domain.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "member_role")
+class MemberRole(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    val role: Role
+) : BaseEntity()

--- a/src/main/kotlin/com/example/mykku/role/domain/Role.kt
+++ b/src/main/kotlin/com/example/mykku/role/domain/Role.kt
@@ -1,0 +1,18 @@
+package com.example.mykku.role.domain
+
+import com.example.mykku.common.domain.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "role")
+class Role(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true, length = 50)
+    var name: String,
+
+    @Column(length = 200)
+    var description: String? = null
+) : BaseEntity()

--- a/src/main/kotlin/com/example/mykku/role/dto/CreateRoleRequest.kt
+++ b/src/main/kotlin/com/example/mykku/role/dto/CreateRoleRequest.kt
@@ -1,0 +1,13 @@
+package com.example.mykku.role.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateRoleRequest(
+    @field:NotBlank(message = "칭호 이름은 필수입니다")
+    @field:Size(max = 50, message = "칭호 이름은 50자 이하여야 합니다")
+    val name: String,
+
+    @field:Size(max = 200, message = "칭호 설명은 200자 이하여야 합니다")
+    val description: String? = null
+)

--- a/src/main/kotlin/com/example/mykku/role/dto/MemberRoleResponse.kt
+++ b/src/main/kotlin/com/example/mykku/role/dto/MemberRoleResponse.kt
@@ -13,7 +13,7 @@ data class MemberRoleResponse(
     constructor(memberRole: MemberRole, member: Member) : this(
         id = memberRole.id!!,
         role = RoleResponse(memberRole.role),
-        isRepresentative = member.role.id == memberRole.role.id,
+        isRepresentative = member.role?.id == memberRole.role.id,
         earnedAt = memberRole.createdAt
     )
 }

--- a/src/main/kotlin/com/example/mykku/role/dto/MemberRoleResponse.kt
+++ b/src/main/kotlin/com/example/mykku/role/dto/MemberRoleResponse.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.role.dto
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import java.time.LocalDateTime
+
+data class MemberRoleResponse(
+    val id: Long,
+    val role: RoleResponse,
+    val isRepresentative: Boolean,
+    val earnedAt: LocalDateTime
+) {
+    constructor(memberRole: MemberRole, member: Member) : this(
+        id = memberRole.id!!,
+        role = RoleResponse(memberRole.role),
+        isRepresentative = member.role.id == memberRole.role.id,
+        earnedAt = memberRole.createdAt
+    )
+}

--- a/src/main/kotlin/com/example/mykku/role/dto/RoleResponse.kt
+++ b/src/main/kotlin/com/example/mykku/role/dto/RoleResponse.kt
@@ -1,0 +1,15 @@
+package com.example.mykku.role.dto
+
+import com.example.mykku.role.domain.Role
+
+data class RoleResponse(
+    val id: Long,
+    val name: String,
+    val description: String?
+) {
+    constructor(role: Role) : this(
+        id = role.id!!,
+        name = role.name,
+        description = role.description
+    )
+}

--- a/src/main/kotlin/com/example/mykku/role/dto/UpdateRoleRequest.kt
+++ b/src/main/kotlin/com/example/mykku/role/dto/UpdateRoleRequest.kt
@@ -1,0 +1,13 @@
+package com.example.mykku.role.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateRoleRequest(
+    @field:NotBlank(message = "칭호 이름은 필수입니다")
+    @field:Size(max = 50, message = "칭호 이름은 50자 이하여야 합니다")
+    val name: String,
+
+    @field:Size(max = 200, message = "칭호 설명은 200자 이하여야 합니다")
+    val description: String? = null
+)

--- a/src/main/kotlin/com/example/mykku/role/exception/RoleErrorCode.kt
+++ b/src/main/kotlin/com/example/mykku/role/exception/RoleErrorCode.kt
@@ -1,0 +1,18 @@
+package com.example.mykku.role.exception
+
+import com.example.mykku.common.exception.DomainErrorCode
+import org.springframework.http.HttpStatus
+
+enum class RoleErrorCode(
+    override val status: HttpStatus,
+    override val message: String
+) : DomainErrorCode {
+    ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "칭호를 찾을 수 없습니다"),
+    ROLE_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 존재하는 칭호 이름입니다"),
+    ROLE_IN_USE(HttpStatus.BAD_REQUEST, "사용 중인 칭호는 삭제할 수 없습니다"),
+
+    MEMBER_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "보유하지 않은 칭호입니다"),
+    MEMBER_ROLE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 보유한 칭호입니다"),
+    MEMBER_ROLE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "해당 칭호에 접근할 권한이 없습니다"),
+    REPRESENTATIVE_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "대표 칭호는 필수입니다")
+}

--- a/src/main/kotlin/com/example/mykku/role/exception/RoleException.kt
+++ b/src/main/kotlin/com/example/mykku/role/exception/RoleException.kt
@@ -1,0 +1,21 @@
+package com.example.mykku.role.exception
+
+import com.example.mykku.common.exception.BaseDomainException
+
+class RoleException(
+    errorCode: RoleErrorCode,
+    additionalMessage: String? = null,
+    cause: Throwable? = null
+) : BaseDomainException(errorCode, additionalMessage, cause) {
+
+    companion object {
+        fun roleNotFound(): RoleException = RoleException(RoleErrorCode.ROLE_NOT_FOUND)
+        fun roleNameDuplicate(): RoleException = RoleException(RoleErrorCode.ROLE_NAME_DUPLICATE)
+        fun roleInUse(): RoleException = RoleException(RoleErrorCode.ROLE_IN_USE)
+
+        fun memberRoleNotFound(): RoleException = RoleException(RoleErrorCode.MEMBER_ROLE_NOT_FOUND)
+        fun memberRoleAlreadyExists(): RoleException = RoleException(RoleErrorCode.MEMBER_ROLE_ALREADY_EXISTS)
+        fun memberRoleUnauthorized(): RoleException = RoleException(RoleErrorCode.MEMBER_ROLE_UNAUTHORIZED)
+        fun representativeRoleRequired(): RoleException = RoleException(RoleErrorCode.REPRESENTATIVE_ROLE_REQUIRED)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/exception/RoleExceptionHandler.kt
+++ b/src/main/kotlin/com/example/mykku/role/exception/RoleExceptionHandler.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.role.exception
+
+import com.example.mykku.common.exception.ErrorResponse
+import com.example.mykku.common.exception.ExceptionLoggingSupport
+import org.slf4j.LoggerFactory
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class RoleExceptionHandler {
+
+    private val logger = LoggerFactory.getLogger(RoleExceptionHandler::class.java)
+
+    @ExceptionHandler(RoleException::class)
+    fun handleRoleException(exception: RoleException): ResponseEntity<ErrorResponse> {
+        ExceptionLoggingSupport.logException(logger, exception)
+
+        return ResponseEntity
+            .status(exception.errorCode.status)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(ErrorResponse(exception.errorCode.message))
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/repository/MemberRoleRepository.kt
+++ b/src/main/kotlin/com/example/mykku/role/repository/MemberRoleRepository.kt
@@ -1,0 +1,19 @@
+package com.example.mykku.role.repository
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberRoleRepository : JpaRepository<MemberRole, Long> {
+    fun findByMember(member: Member): List<MemberRole>
+    fun findByMemberAndRole(member: Member, role: Role): MemberRole?
+    fun existsByMemberAndRole(member: Member, role: Role): Boolean
+    fun existsByRole(role: Role): Boolean
+
+    @Query("SELECT mr FROM MemberRole mr JOIN FETCH mr.role WHERE mr.member = :member")
+    fun findByMemberWithRole(member: Member): List<MemberRole>
+}

--- a/src/main/kotlin/com/example/mykku/role/repository/RoleRepository.kt
+++ b/src/main/kotlin/com/example/mykku/role/repository/RoleRepository.kt
@@ -1,0 +1,11 @@
+package com.example.mykku.role.repository
+
+import com.example.mykku.role.domain.Role
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RoleRepository : JpaRepository<Role, Long> {
+    fun findByName(name: String): Role?
+    fun existsByName(name: String): Boolean
+}

--- a/src/main/kotlin/com/example/mykku/role/tool/MemberRoleReader.kt
+++ b/src/main/kotlin/com/example/mykku/role/tool/MemberRoleReader.kt
@@ -1,0 +1,28 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.MemberRoleRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class MemberRoleReader(
+    private val memberRoleRepository: MemberRoleRepository
+) {
+    fun getMemberRolesByMember(member: Member): List<MemberRole> {
+        return memberRoleRepository.findByMemberWithRole(member)
+    }
+
+    fun getMemberRoleById(memberRoleId: Long, member: Member): MemberRole {
+        val memberRole = memberRoleRepository.findByIdOrNull(memberRoleId)
+            ?: throw RoleException.memberRoleNotFound()
+
+        if (memberRole.member.id != member.id) {
+            throw RoleException.memberRoleUnauthorized()
+        }
+
+        return memberRole
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/tool/MemberRoleReader.kt
+++ b/src/main/kotlin/com/example/mykku/role/tool/MemberRoleReader.kt
@@ -2,6 +2,7 @@ package com.example.mykku.role.tool
 
 import com.example.mykku.member.domain.Member
 import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
 import com.example.mykku.role.exception.RoleException
 import com.example.mykku.role.repository.MemberRoleRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -24,5 +25,9 @@ class MemberRoleReader(
         }
 
         return memberRole
+    }
+
+    fun existsByRole(role: Role): Boolean {
+        return memberRoleRepository.existsByRole(role)
     }
 }

--- a/src/main/kotlin/com/example/mykku/role/tool/MemberRoleWriter.kt
+++ b/src/main/kotlin/com/example/mykku/role/tool/MemberRoleWriter.kt
@@ -1,0 +1,29 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.MemberRoleRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MemberRoleWriter(
+    private val memberRoleRepository: MemberRoleRepository
+) {
+    fun assignRole(member: Member, role: Role): MemberRole {
+        if (memberRoleRepository.existsByMemberAndRole(member, role)) {
+            throw RoleException.memberRoleAlreadyExists()
+        }
+
+        val memberRole = MemberRole(
+            member = member,
+            role = role
+        )
+        return memberRoleRepository.save(memberRole)
+    }
+
+    fun delete(memberRole: MemberRole) {
+        memberRoleRepository.delete(memberRole)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/tool/RoleReader.kt
+++ b/src/main/kotlin/com/example/mykku/role/tool/RoleReader.kt
@@ -1,0 +1,30 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.RoleRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class RoleReader(
+    private val roleRepository: RoleRepository
+) {
+    fun getRoleById(roleId: Long): Role {
+        return roleRepository.findByIdOrNull(roleId)
+            ?: throw RoleException.roleNotFound()
+    }
+
+    fun getRoleByName(name: String): Role {
+        return roleRepository.findByName(name)
+            ?: throw RoleException.roleNotFound()
+    }
+
+    fun getAllRoles(): List<Role> {
+        return roleRepository.findAll()
+    }
+
+    fun existsByName(name: String): Boolean {
+        return roleRepository.existsByName(name)
+    }
+}

--- a/src/main/kotlin/com/example/mykku/role/tool/RoleWriter.kt
+++ b/src/main/kotlin/com/example/mykku/role/tool/RoleWriter.kt
@@ -1,0 +1,41 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.RoleRepository
+import org.springframework.stereotype.Component
+
+@Component
+class RoleWriter(
+    private val roleRepository: RoleRepository
+) {
+    fun save(role: Role): Role {
+        return roleRepository.save(role)
+    }
+
+    fun create(name: String, description: String?): Role {
+        if (roleRepository.existsByName(name)) {
+            throw RoleException.roleNameDuplicate()
+        }
+
+        val role = Role(
+            name = name,
+            description = description
+        )
+        return roleRepository.save(role)
+    }
+
+    fun update(role: Role, name: String, description: String?): Role {
+        if (role.name != name && roleRepository.existsByName(name)) {
+            throw RoleException.roleNameDuplicate()
+        }
+
+        role.name = name
+        role.description = description
+        return roleRepository.save(role)
+    }
+
+    fun delete(role: Role) {
+        roleRepository.delete(role)
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,9 +15,9 @@ spring:
       add-mappings: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/mykku_test
+    url: jdbc:mysql://localhost:3311/mykku_test
     username: root
-    password:
+    password: root
   jpa:
     show-sql: true
     properties:
@@ -25,7 +25,7 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
   mail:
     host: localhost
     port: 25

--- a/src/main/resources/db/migration/V8__add_role_tables.sql
+++ b/src/main/resources/db/migration/V8__add_role_tables.sql
@@ -1,0 +1,67 @@
+-- V8: Add Role and MemberRole tables
+
+-- 1. Create Role table (칭호 마스터)
+CREATE TABLE role
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name        VARCHAR(50)  NOT NULL UNIQUE,
+    description VARCHAR(200),
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL
+);
+
+-- 2. Insert default roles
+INSERT INTO role (name, description, created_at, updated_at)
+VALUES ('신입 덕후', '처음 시작하는 덕후를 위한 칭호', NOW(6), NOW(6)),
+       ('열정 덕후', '활발한 활동을 보이는 덕후', NOW(6), NOW(6)),
+       ('베테랑 덕후', '오래된 경력의 덕후', NOW(6), NOW(6));
+
+-- 3. Create MemberRole table (사용자 보유 칭호)
+CREATE TABLE member_role
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  VARCHAR(255) NOT NULL,
+    role_id    BIGINT       NOT NULL,
+    created_at DATETIME(6)  NOT NULL,
+    updated_at DATETIME(6)  NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE RESTRICT,
+    UNIQUE KEY unique_member_role (member_id, role_id)
+);
+
+CREATE INDEX idx_member_role_member ON member_role (member_id);
+
+-- 4. Add role_id column to member table
+ALTER TABLE member
+    ADD COLUMN role_id BIGINT;
+
+ALTER TABLE member
+    ADD FOREIGN KEY (role_id) REFERENCES role (id);
+
+-- 5. Assign default role to existing members
+-- 5-1. Grant "신입 덕후" to all existing members (member_role)
+INSERT INTO member_role (member_id, role_id, created_at, updated_at)
+SELECT m.id, r.id, NOW(6), NOW(6)
+FROM member m
+         CROSS JOIN role r
+WHERE r.name = '신입 덕후'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM member_role mr
+        WHERE mr.member_id = m.id
+          AND mr.role_id = r.id
+    );
+
+-- 5-2. Set representative role to "신입 덕후" for all existing members
+UPDATE member m
+    JOIN role r ON r.name = '신입 덕후'
+SET m.role_id = r.id
+WHERE m.role_id IS NULL;
+
+-- 6. Make role_id NOT NULL
+ALTER TABLE member
+    MODIFY COLUMN role_id BIGINT NOT NULL;
+
+-- 7. Drop old role column
+ALTER TABLE member
+    DROP COLUMN role;

--- a/src/main/resources/db/migration/V8__add_role_tables.sql
+++ b/src/main/resources/db/migration/V8__add_role_tables.sql
@@ -1,6 +1,5 @@
 -- V8: Add Role and MemberRole tables
 
--- 1. Create Role table (칭호 마스터)
 CREATE TABLE role
 (
     id          BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -10,13 +9,6 @@ CREATE TABLE role
     updated_at  DATETIME(6)  NOT NULL
 );
 
--- 2. Insert default roles
-INSERT INTO role (name, description, created_at, updated_at)
-VALUES ('신입 덕후', '처음 시작하는 덕후를 위한 칭호', NOW(6), NOW(6)),
-       ('열정 덕후', '활발한 활동을 보이는 덕후', NOW(6), NOW(6)),
-       ('베테랑 덕후', '오래된 경력의 덕후', NOW(6), NOW(6));
-
--- 3. Create MemberRole table (사용자 보유 칭호)
 CREATE TABLE member_role
 (
     id         BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -25,43 +17,17 @@ CREATE TABLE member_role
     created_at DATETIME(6)  NOT NULL,
     updated_at DATETIME(6)  NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
-    FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE RESTRICT,
+    FOREIGN KEY (role_id) REFERENCES role (id),
     UNIQUE KEY unique_member_role (member_id, role_id)
 );
 
 CREATE INDEX idx_member_role_member ON member_role (member_id);
 
--- 4. Add role_id column to member table
 ALTER TABLE member
     ADD COLUMN role_id BIGINT;
 
 ALTER TABLE member
     ADD FOREIGN KEY (role_id) REFERENCES role (id);
 
--- 5. Assign default role to existing members
--- 5-1. Grant "신입 덕후" to all existing members (member_role)
-INSERT INTO member_role (member_id, role_id, created_at, updated_at)
-SELECT m.id, r.id, NOW(6), NOW(6)
-FROM member m
-         CROSS JOIN role r
-WHERE r.name = '신입 덕후'
-  AND NOT EXISTS (
-        SELECT 1
-        FROM member_role mr
-        WHERE mr.member_id = m.id
-          AND mr.role_id = r.id
-    );
-
--- 5-2. Set representative role to "신입 덕후" for all existing members
-UPDATE member m
-    JOIN role r ON r.name = '신입 덕후'
-SET m.role_id = r.id
-WHERE m.role_id IS NULL;
-
--- 6. Make role_id NOT NULL
-ALTER TABLE member
-    MODIFY COLUMN role_id BIGINT NOT NULL;
-
--- 7. Drop old role column
 ALTER TABLE member
     DROP COLUMN role;

--- a/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
@@ -7,6 +7,8 @@ import com.example.mykku.config.TestEmailSenderConfig
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
 import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.repository.RoleRepository
 import com.example.mykku.util.DatabaseCleaner
 import com.example.mykku.util.TestTokenGenerator
 import io.restassured.RestAssured
@@ -33,6 +35,9 @@ abstract class BaseControllerTest {
     @Autowired
     protected lateinit var boardRepository: BoardRepository
 
+    @Autowired
+    protected lateinit var roleRepository: RoleRepository
+
     @BeforeEach
     fun baseSetUp() {
         RestAssured.port = port
@@ -47,9 +52,12 @@ abstract class BaseControllerTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        role: String = "USER",
+        roleName: String = "일반 덕후",
         profileImage: String = ""
     ): Member {
+        val role = roleRepository.findByName(roleName)
+            ?: roleRepository.save(Role(name = roleName, description = "테스트용 칭호"))
+
         val member = Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
@@ -94,4 +94,20 @@ abstract class BaseControllerTest {
     protected fun createAuthHeaders(memberId: String): Map<String, String> {
         return TestTokenGenerator.createAuthHeaders(memberId)
     }
+
+    /**
+     * 관리자 세션 생성 및 SessionId 반환
+     */
+    protected fun getAdminSessionId(): String {
+        return RestAssured
+            .given()
+                .formParam("token", "test-admin-token")
+                .redirects().follow(false)
+            .`when`()
+                .post("/admin/api/login")
+            .then()
+                .statusCode(302)
+                .extract()
+                .sessionId()
+    }
 }

--- a/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseControllerTest.kt
@@ -52,12 +52,9 @@ abstract class BaseControllerTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        roleName: String = "일반 덕후",
+        role: Role? = null,
         profileImage: String = ""
     ): Member {
-        val role = roleRepository.findByName(roleName)
-            ?: roleRepository.save(Role(name = roleName, description = "테스트용 칭호"))
-
         val member = Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseRepositoryTest.kt
@@ -38,12 +38,9 @@ abstract class BaseRepositoryTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        roleName: String = "일반 덕후",
+        role: Role? = null,
         profileImage: String = ""
     ): Member {
-        val role = roleRepository.findByName(roleName)
-            ?: roleRepository.save(Role(name = roleName, description = "테스트용 칭호"))
-
         val member = Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseRepositoryTest.kt
@@ -5,6 +5,8 @@ import com.example.mykku.board.repository.BoardRepository
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
 import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.repository.RoleRepository
 import com.example.mykku.util.DatabaseCleaner
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,6 +26,9 @@ abstract class BaseRepositoryTest {
     @Autowired
     protected lateinit var boardRepository: BoardRepository
 
+    @Autowired
+    protected lateinit var roleRepository: RoleRepository
+
     /**
      * 테스트용 Member 엔티티 생성 및 저장
      */
@@ -33,9 +38,12 @@ abstract class BaseRepositoryTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        role: String = "USER",
+        roleName: String = "일반 덕후",
         profileImage: String = ""
     ): Member {
+        val role = roleRepository.findByName(roleName)
+            ?: roleRepository.save(Role(name = roleName, description = "테스트용 칭호"))
+
         val member = Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseServiceTest.kt
@@ -4,6 +4,7 @@ import com.example.mykku.board.domain.Board
 import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
+import com.example.mykku.role.domain.Role
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDateTime
@@ -20,9 +21,11 @@ abstract class BaseServiceTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        role: String = "USER",
+        roleName: String = "일반 덕후",
         profileImage: String = ""
     ): Member {
+        val role = Role(name = roleName, description = "테스트용 칭호")
+
         return Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseServiceTest.kt
@@ -21,11 +21,9 @@ abstract class BaseServiceTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        roleName: String = "일반 덕후",
+        role: Role? = null,
         profileImage: String = ""
     ): Member {
-        val role = Role(name = roleName, description = "테스트용 칭호")
-
         return Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseToolTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseToolTest.kt
@@ -19,11 +19,9 @@ abstract class BaseToolTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        roleName: String = "일반 덕후",
+        role: Role? = null,
         profileImage: String = ""
     ): Member {
-        val role = Role(name = roleName, description = "테스트용 칭호")
-
         return Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/BaseToolTest.kt
+++ b/src/test/kotlin/com/example/mykku/BaseToolTest.kt
@@ -3,6 +3,7 @@ package com.example.mykku
 import com.example.mykku.board.domain.Board
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
+import com.example.mykku.role.domain.Role
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 
@@ -18,9 +19,11 @@ abstract class BaseToolTest {
         email: String = "test@example.com",
         socialId: String = "12345",
         provider: SocialProvider = SocialProvider.GOOGLE,
-        role: String = "USER",
+        roleName: String = "일반 덕후",
         profileImage: String = ""
     ): Member {
+        val role = Role(name = roleName, description = "테스트용 칭호")
+
         return Member(
             id = id,
             nickname = nickname,

--- a/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
@@ -21,11 +21,13 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
 
     private lateinit var role1: Role
     private lateinit var role2: Role
+    private lateinit var adminSessionId: String
 
     @BeforeEach
     fun setUp() {
         role1 = roleRepository.save(Role(name = "칭호1", description = "설명1"))
         role2 = roleRepository.save(Role(name = "칭호2", description = "설명2"))
+        adminSessionId = getAdminSessionId()
     }
 
     @Test
@@ -34,6 +36,7 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
         // when & then
         RestAssured
             .given()
+                .sessionId(adminSessionId)
                 .contentType(ContentType.JSON)
             .`when`()
                 .get("/admin/api/v1/roles")
@@ -52,6 +55,7 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
         // when & then
         RestAssured
             .given()
+                .sessionId(adminSessionId)
                 .contentType(ContentType.JSON)
                 .body(request)
             .`when`()
@@ -72,6 +76,7 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
         // when & then
         RestAssured
             .given()
+                .sessionId(adminSessionId)
                 .contentType(ContentType.JSON)
                 .body(request)
             .`when`()
@@ -91,6 +96,7 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
         // when & then
         RestAssured
             .given()
+                .sessionId(adminSessionId)
                 .contentType(ContentType.JSON)
             .`when`()
                 .delete("/admin/api/v1/roles/${roleToDelete.id}")
@@ -112,6 +118,7 @@ class AdminRoleApiControllerTest : BaseControllerTest() {
         // when & then
         RestAssured
             .given()
+                .sessionId(adminSessionId)
                 .contentType(ContentType.JSON)
             .`when`()
                 .post("/admin/api/v1/roles/${role2.id}/members/${member.id}")

--- a/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
@@ -1,0 +1,132 @@
+package com.example.mykku.admin.controller
+
+import com.example.mykku.admin.service.AdminRoleService
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.dto.CreateRoleRequest
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.example.mykku.role.dto.RoleResponse
+import com.example.mykku.role.dto.UpdateRoleRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(AdminRoleApiController::class)
+class AdminRoleApiControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var adminRoleService: AdminRoleService
+
+    private lateinit var role: Role
+
+    @BeforeEach
+    fun setUp() {
+        role = Role(id = 1L, name = "테스트 칭호", description = "테스트 설명")
+    }
+
+    @Test
+    @WithMockUser
+    fun `모든 칭호를 조회할 수 있다`() {
+        val roles = listOf(
+            RoleResponse(Role(id = 1L, name = "칭호1", description = "설명1")),
+            RoleResponse(Role(id = 2L, name = "칭호2", description = "설명2"))
+        )
+        whenever(adminRoleService.getAllRoles()).thenReturn(roles)
+
+        mockMvc.perform(
+            get("/admin/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 목록 조회 성공"))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(2))
+    }
+
+    @Test
+    @WithMockUser
+    fun `새로운 칭호를 생성할 수 있다`() {
+        val request = CreateRoleRequest(name = "새 칭호", description = "새 설명")
+        val response = RoleResponse(role)
+        whenever(adminRoleService.createRole(any<CreateRoleRequest>())).thenReturn(response)
+
+        mockMvc.perform(
+            post("/admin/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("칭호 생성 성공"))
+            .andExpect(jsonPath("$.data.name").value("테스트 칭호"))
+    }
+
+    @Test
+    @WithMockUser
+    fun `칭호를 수정할 수 있다`() {
+        val request = UpdateRoleRequest(name = "수정된 칭호", description = "수정된 설명")
+        val response = RoleResponse(role)
+        whenever(adminRoleService.updateRole(any<Long>(), any<UpdateRoleRequest>())).thenReturn(response)
+
+        mockMvc.perform(
+            put("/admin/api/v1/roles/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 수정 성공"))
+    }
+
+    @Test
+    @WithMockUser
+    fun `칭호를 삭제할 수 있다`() {
+        mockMvc.perform(
+            delete("/admin/api/v1/roles/1")
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 삭제 성공"))
+    }
+
+    @Test
+    @WithMockUser
+    fun `회원에게 칭호를 부여할 수 있다`() {
+        val member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role
+        )
+        val memberRole = MemberRole(id = 1L, member = member, role = role)
+        val response = MemberRoleResponse(memberRole, member)
+        whenever(adminRoleService.assignRoleToMember(any<Long>(), any<String>())).thenReturn(response)
+
+        mockMvc.perform(
+            post("/admin/api/v1/roles/1/members/test-id")
+                .with(csrf())
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("칭호 부여 성공"))
+    }
+}

--- a/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/controller/AdminRoleApiControllerTest.kt
@@ -1,132 +1,123 @@
 package com.example.mykku.admin.controller
 
-import com.example.mykku.admin.service.AdminRoleService
-import com.example.mykku.member.domain.Member
-import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.BaseControllerTest
 import com.example.mykku.role.domain.Role
 import com.example.mykku.role.dto.CreateRoleRequest
-import com.example.mykku.role.dto.MemberRoleResponse
-import com.example.mykku.role.dto.RoleResponse
 import com.example.mykku.role.dto.UpdateRoleRequest
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.example.mykku.role.repository.MemberRoleRepository
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.MediaType
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest(AdminRoleApiController::class)
-class AdminRoleApiControllerTest {
+@DisplayName("AdminRoleApiController 통합 테스트")
+class AdminRoleApiControllerTest : BaseControllerTest() {
 
     @Autowired
-    private lateinit var mockMvc: MockMvc
+    private lateinit var memberRoleRepository: MemberRoleRepository
 
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
-    @MockBean
-    private lateinit var adminRoleService: AdminRoleService
-
-    private lateinit var role: Role
+    private lateinit var role1: Role
+    private lateinit var role2: Role
 
     @BeforeEach
     fun setUp() {
-        role = Role(id = 1L, name = "테스트 칭호", description = "테스트 설명")
+        role1 = roleRepository.save(Role(name = "칭호1", description = "설명1"))
+        role2 = roleRepository.save(Role(name = "칭호2", description = "설명2"))
     }
 
     @Test
-    @WithMockUser
-    fun `모든 칭호를 조회할 수 있다`() {
-        val roles = listOf(
-            RoleResponse(Role(id = 1L, name = "칭호1", description = "설명1")),
-            RoleResponse(Role(id = 2L, name = "칭호2", description = "설명2"))
-        )
-        whenever(adminRoleService.getAllRoles()).thenReturn(roles)
-
-        mockMvc.perform(
-            get("/admin/api/v1/roles")
-                .contentType(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("칭호 목록 조회 성공"))
-            .andExpect(jsonPath("$.data").isArray)
-            .andExpect(jsonPath("$.data.length()").value(2))
+    @DisplayName("모든 칭호를 조회할 수 있다")
+    fun `getAllRoles - 모든 칭호를 조회한다`() {
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+            .`when`()
+                .get("/admin/api/v1/roles")
+            .then()
+                .statusCode(200)
+                .body("message", equalTo("칭호 목록 조회 성공"))
+                .body("data", hasSize<Any>(greaterThanOrEqualTo(2)))
     }
 
     @Test
-    @WithMockUser
-    fun `새로운 칭호를 생성할 수 있다`() {
-        val request = CreateRoleRequest(name = "새 칭호", description = "새 설명")
-        val response = RoleResponse(role)
-        whenever(adminRoleService.createRole(any<CreateRoleRequest>())).thenReturn(response)
+    @DisplayName("새로운 칭호를 생성할 수 있다")
+    fun `createRole - 새로운 칭호를 생성한다`() {
+        // given
+        val request = CreateRoleRequest(name = "새로운칭호", description = "새로운 설명")
 
-        mockMvc.perform(
-            post("/admin/api/v1/roles")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .with(csrf())
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.message").value("칭호 생성 성공"))
-            .andExpect(jsonPath("$.data.name").value("테스트 칭호"))
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+            .`when`()
+                .post("/admin/api/v1/roles")
+            .then()
+                .statusCode(201)
+                .body("message", equalTo("칭호 생성 성공"))
+                .body("data.name", equalTo("새로운칭호"))
+                .body("data.description", equalTo("새로운 설명"))
     }
 
     @Test
-    @WithMockUser
-    fun `칭호를 수정할 수 있다`() {
-        val request = UpdateRoleRequest(name = "수정된 칭호", description = "수정된 설명")
-        val response = RoleResponse(role)
-        whenever(adminRoleService.updateRole(any<Long>(), any<UpdateRoleRequest>())).thenReturn(response)
+    @DisplayName("칭호를 수정할 수 있다")
+    fun `updateRole - 칭호를 수정한다`() {
+        // given
+        val request = UpdateRoleRequest(name = "수정된칭호", description = "수정된 설명")
 
-        mockMvc.perform(
-            put("/admin/api/v1/roles/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .with(csrf())
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("칭호 수정 성공"))
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+            .`when`()
+                .put("/admin/api/v1/roles/${role1.id}")
+            .then()
+                .statusCode(200)
+                .body("message", equalTo("칭호 수정 성공"))
+                .body("data.name", equalTo("수정된칭호"))
     }
 
     @Test
-    @WithMockUser
-    fun `칭호를 삭제할 수 있다`() {
-        mockMvc.perform(
-            delete("/admin/api/v1/roles/1")
-                .with(csrf())
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("칭호 삭제 성공"))
+    @DisplayName("칭호를 삭제할 수 있다")
+    fun `deleteRole - 칭호를 삭제한다`() {
+        // given
+        val roleToDelete = roleRepository.save(Role(name = "삭제될칭호", description = "설명"))
+
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+            .`when`()
+                .delete("/admin/api/v1/roles/${roleToDelete.id}")
+            .then()
+                .statusCode(200)
+                .body("message", equalTo("칭호 삭제 성공"))
     }
 
     @Test
-    @WithMockUser
-    fun `회원에게 칭호를 부여할 수 있다`() {
-        val member = Member.createEmailMember(
-            id = "test-id",
-            email = "test@example.com",
-            password = "password",
+    @DisplayName("회원에게 칭호를 부여할 수 있다")
+    fun `assignRoleToMember - 회원에게 칭호를 부여한다`() {
+        // given
+        val member = createAndSaveMember(
+            id = "test-member",
             nickname = "테스터",
-            defaultRole = role
+            role = role1
         )
-        val memberRole = MemberRole(id = 1L, member = member, role = role)
-        val response = MemberRoleResponse(memberRole, member)
-        whenever(adminRoleService.assignRoleToMember(any<Long>(), any<String>())).thenReturn(response)
 
-        mockMvc.perform(
-            post("/admin/api/v1/roles/1/members/test-id")
-                .with(csrf())
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.message").value("칭호 부여 성공"))
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+            .`when`()
+                .post("/admin/api/v1/roles/${role2.id}/members/${member.id}")
+            .then()
+                .statusCode(201)
+                .body("message", equalTo("칭호 부여 성공"))
+                .body("data.role.name", equalTo(role2.name))
     }
 }

--- a/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
@@ -1,0 +1,145 @@
+package com.example.mykku.admin.service
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.tool.MemberReader
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.dto.CreateRoleRequest
+import com.example.mykku.role.dto.UpdateRoleRequest
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.tool.MemberRoleWriter
+import com.example.mykku.role.tool.RoleReader
+import com.example.mykku.role.tool.RoleWriter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class AdminRoleServiceTest {
+
+    @Mock
+    private lateinit var roleReader: RoleReader
+
+    @Mock
+    private lateinit var roleWriter: RoleWriter
+
+    @Mock
+    private lateinit var memberReader: MemberReader
+
+    @Mock
+    private lateinit var memberRoleWriter: MemberRoleWriter
+
+    @InjectMocks
+    private lateinit var adminRoleService: AdminRoleService
+
+    private lateinit var role: Role
+
+    @BeforeEach
+    fun setUp() {
+        role = Role(id = 1L, name = "테스트 칭호", description = "테스트 설명")
+    }
+
+    @Test
+    fun `모든 칭호를 조회할 수 있다`() {
+        val roles = listOf(
+            Role(id = 1L, name = "칭호1", description = "설명1"),
+            Role(id = 2L, name = "칭호2", description = "설명2")
+        )
+        whenever(roleReader.getAllRoles()).thenReturn(roles)
+
+        val result = adminRoleService.getAllRoles()
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.name }).contains("칭호1", "칭호2")
+        verify(roleReader).getAllRoles()
+    }
+
+    @Test
+    fun `새로운 칭호를 생성할 수 있다`() {
+        val request = CreateRoleRequest(name = "새 칭호", description = "새 설명")
+        whenever(roleReader.existsByName("새 칭호")).thenReturn(false)
+        whenever(roleWriter.create("새 칭호", "새 설명")).thenReturn(role)
+
+        val result = adminRoleService.createRole(request)
+
+        assertThat(result.name).isEqualTo("테스트 칭호")
+        verify(roleReader).existsByName("새 칭호")
+        verify(roleWriter).create("새 칭호", "새 설명")
+    }
+
+    @Test
+    fun `이미 존재하는 이름으로 칭호를 생성하면 예외가 발생한다`() {
+        val request = CreateRoleRequest(name = "중복 칭호", description = "설명")
+        whenever(roleReader.existsByName("중복 칭호")).thenReturn(true)
+
+        val exception = assertThrows<RoleException> {
+            adminRoleService.createRole(request)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_NAME_DUPLICATE)
+    }
+
+    @Test
+    fun `칭호를 수정할 수 있다`() {
+        val request = UpdateRoleRequest(name = "수정된 칭호", description = "수정된 설명")
+        whenever(roleReader.getRoleById(1L)).thenReturn(role)
+        whenever(roleReader.existsByName("수정된 칭호")).thenReturn(false)
+
+        val result = adminRoleService.updateRole(1L, request)
+
+        verify(roleReader).getRoleById(1L)
+        verify(roleWriter).update(role, "수정된 칭호", "수정된 설명")
+    }
+
+    @Test
+    fun `칭호 수정 시 다른 칭호와 이름이 중복되면 예외가 발생한다`() {
+        val request = UpdateRoleRequest(name = "중복 이름", description = "설명")
+        val existingRole = Role(id = 2L, name = "중복 이름", description = "")
+        whenever(roleReader.getRoleById(1L)).thenReturn(role)
+        whenever(roleReader.existsByName("중복 이름")).thenReturn(true)
+
+        val exception = assertThrows<RoleException> {
+            adminRoleService.updateRole(1L, request)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_NAME_DUPLICATE)
+    }
+
+    @Test
+    fun `칭호를 삭제할 수 있다`() {
+        whenever(roleReader.getRoleById(1L)).thenReturn(role)
+
+        adminRoleService.deleteRole(1L)
+
+        verify(roleReader).getRoleById(1L)
+        verify(roleWriter).delete(role)
+    }
+
+    @Test
+    fun `회원에게 칭호를 부여할 수 있다`() {
+        val member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role
+        )
+        whenever(roleReader.getRoleById(1L)).thenReturn(role)
+        whenever(memberReader.getMemberById("test-id")).thenReturn(member)
+        whenever(memberRoleWriter.assignRole(member, role)).thenReturn(any())
+
+        adminRoleService.assignRoleToMember(1L, "test-id")
+
+        verify(roleReader).getRoleById(1L)
+        verify(memberReader).getMemberById("test-id")
+        verify(memberRoleWriter).assignRole(member, role)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
@@ -2,6 +2,7 @@ package com.example.mykku.admin.service
 
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.tool.MemberReader
+import com.example.mykku.role.domain.MemberRole
 import com.example.mykku.role.domain.Role
 import com.example.mykku.role.dto.CreateRoleRequest
 import com.example.mykku.role.dto.UpdateRoleRequest
@@ -69,20 +70,18 @@ class AdminRoleServiceTest {
     @Test
     fun `새로운 칭호를 생성할 수 있다`() {
         val request = CreateRoleRequest(name = "새 칭호", description = "새 설명")
-        whenever(roleReader.existsByName("새 칭호")).thenReturn(false)
         whenever(roleWriter.create("새 칭호", "새 설명")).thenReturn(role)
 
         val result = adminRoleService.createRole(request)
 
         assertThat(result.name).isEqualTo("테스트 칭호")
-        verify(roleReader).existsByName("새 칭호")
         verify(roleWriter).create("새 칭호", "새 설명")
     }
 
     @Test
     fun `이미 존재하는 이름으로 칭호를 생성하면 예외가 발생한다`() {
         val request = CreateRoleRequest(name = "중복 칭호", description = "설명")
-        whenever(roleReader.existsByName("중복 칭호")).thenReturn(true)
+        whenever(roleWriter.create("중복 칭호", "설명")).thenThrow(RoleException.roleNameDuplicate())
 
         val exception = assertThrows<RoleException> {
             adminRoleService.createRole(request)
@@ -95,9 +94,9 @@ class AdminRoleServiceTest {
     fun `칭호를 수정할 수 있다`() {
         val request = UpdateRoleRequest(name = "수정된 칭호", description = "수정된 설명")
         whenever(roleReader.getRoleById(1L)).thenReturn(role)
-        whenever(roleReader.existsByName("수정된 칭호")).thenReturn(false)
+        whenever(roleWriter.update(role, "수정된 칭호", "수정된 설명")).thenReturn(role)
 
-        val result = adminRoleService.updateRole(1L, request)
+        adminRoleService.updateRole(1L, request)
 
         verify(roleReader).getRoleById(1L)
         verify(roleWriter).update(role, "수정된 칭호", "수정된 설명")
@@ -106,9 +105,8 @@ class AdminRoleServiceTest {
     @Test
     fun `칭호 수정 시 다른 칭호와 이름이 중복되면 예외가 발생한다`() {
         val request = UpdateRoleRequest(name = "중복 이름", description = "설명")
-        val existingRole = Role(id = 2L, name = "중복 이름", description = "")
         whenever(roleReader.getRoleById(1L)).thenReturn(role)
-        whenever(roleReader.existsByName("중복 이름")).thenReturn(true)
+        whenever(roleWriter.update(role, "중복 이름", "설명")).thenThrow(RoleException.roleNameDuplicate())
 
         val exception = assertThrows<RoleException> {
             adminRoleService.updateRole(1L, request)
@@ -138,11 +136,14 @@ class AdminRoleServiceTest {
             email = "test@example.com",
             password = "password",
             nickname = "테스터",
-            defaultRole = role
         )
+        val memberRole = org.mockito.kotlin.mock<MemberRole>()
+        whenever(memberRole.id).thenReturn(1L)
+        whenever(memberRole.role).thenReturn(role)
+        whenever(memberRole.createdAt).thenReturn(java.time.LocalDateTime.now())
         whenever(roleReader.getRoleById(1L)).thenReturn(role)
         whenever(memberReader.getMemberById("test-id")).thenReturn(member)
-        whenever(memberRoleWriter.assignRole(member, role)).thenReturn(any())
+        whenever(memberRoleWriter.assignRole(member, role)).thenReturn(memberRole)
 
         adminRoleService.assignRoleToMember(1L, "test-id")
 

--- a/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/admin/service/AdminRoleServiceTest.kt
@@ -7,6 +7,7 @@ import com.example.mykku.role.dto.CreateRoleRequest
 import com.example.mykku.role.dto.UpdateRoleRequest
 import com.example.mykku.role.exception.RoleErrorCode
 import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.tool.MemberRoleReader
 import com.example.mykku.role.tool.MemberRoleWriter
 import com.example.mykku.role.tool.RoleReader
 import com.example.mykku.role.tool.RoleWriter
@@ -33,6 +34,9 @@ class AdminRoleServiceTest {
 
     @Mock
     private lateinit var memberReader: MemberReader
+
+    @Mock
+    private lateinit var memberRoleReader: MemberRoleReader
 
     @Mock
     private lateinit var memberRoleWriter: MemberRoleWriter
@@ -116,10 +120,14 @@ class AdminRoleServiceTest {
     @Test
     fun `칭호를 삭제할 수 있다`() {
         whenever(roleReader.getRoleById(1L)).thenReturn(role)
+        whenever(memberReader.existsByRole(role)).thenReturn(false)
+        whenever(memberRoleReader.existsByRole(role)).thenReturn(false)
 
         adminRoleService.deleteRole(1L)
 
         verify(roleReader).getRoleById(1L)
+        verify(memberReader).existsByRole(role)
+        verify(memberRoleReader).existsByRole(role)
         verify(roleWriter).delete(role)
     }
 

--- a/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
@@ -12,6 +12,7 @@ import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import com.example.mykku.role.domain.Role
 
 @DisplayName("AuthController 통합 테스트")
 class AuthControllerTest : BaseControllerTest() {
@@ -30,7 +31,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -80,7 +81,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member2@example.com",
                 nickname = "Member2",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -111,7 +112,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "delete@example.com",
                 nickname = "ToDelete",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/AuthControllerTest.kt
@@ -24,6 +24,7 @@ class AuthControllerTest : BaseControllerTest() {
     @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 정상 케이스")
     fun `refreshToken - 유효한 리프레시 토큰으로 새로운 액세스 토큰을 발급받는다`() {
         // given
+        val role = roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = memberRepository.save(
             Member(
                 id = "member1",
@@ -31,7 +32,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = role,
                 profileImage = ""
             )
         )
@@ -74,6 +75,7 @@ class AuthControllerTest : BaseControllerTest() {
     @DisplayName("리프레시 토큰으로 액세스 토큰 재발급 - 액세스 토큰으로 요청시 실패")
     fun `refreshToken - 액세스 토큰으로 리프레시 요청시 실패한다`() {
         // given
+        val role = roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = memberRepository.save(
             Member(
                 id = "member2",
@@ -81,7 +83,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member2@example.com",
                 nickname = "Member2",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = role,
                 profileImage = ""
             )
         )
@@ -105,6 +107,7 @@ class AuthControllerTest : BaseControllerTest() {
     fun `refreshToken - 존재하지 않는 회원의 리프레시 토큰으로 요청시 실패한다`() {
         // given
         // 토큰 생성 후 회원 삭제 시나리오
+        val role = roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = memberRepository.save(
             Member(
                 id = "member_to_delete",
@@ -112,7 +115,7 @@ class AuthControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "delete@example.com",
                 nickname = "ToDelete",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = role,
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/auth/resolver/MemberArgumentResolverTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/resolver/MemberArgumentResolverTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.core.MethodParameter
 import org.springframework.web.context.request.NativeWebRequest
 import java.util.*
+import com.example.mykku.role.domain.Role
 
 class MemberArgumentResolverTest {
 
@@ -73,7 +74,7 @@ class MemberArgumentResolverTest {
         val member = Member(
             id = memberId,
             nickname = "testuser",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "https://example.com/profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "123456",

--- a/src/test/kotlin/com/example/mykku/auth/resolver/TestMemberArgumentResolver.kt
+++ b/src/test/kotlin/com/example/mykku/auth/resolver/TestMemberArgumentResolver.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
+import com.example.mykku.role.domain.Role
 
 class TestMemberArgumentResolver : HandlerMethodArgumentResolver {
 
@@ -15,7 +16,7 @@ class TestMemberArgumentResolver : HandlerMethodArgumentResolver {
         val TEST_MEMBER = Member(
             id = "member123",
             nickname = "testuser",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "https://example.com/profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "123456",

--- a/src/test/kotlin/com/example/mykku/auth/tool/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/example/mykku/auth/tool/JwtTokenProviderTest.kt
@@ -6,6 +6,7 @@ import com.example.mykku.member.domain.SocialProvider
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import com.example.mykku.role.domain.Role
 
 class JwtTokenProviderTest {
 
@@ -139,7 +140,7 @@ class JwtTokenProviderTest {
         val member = Member(
             id = "google_123456",
             nickname = "testuser",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "https://example.com/profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "123456",

--- a/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import com.example.mykku.role.domain.Role
 
 @DisplayName("DailyMessageCommentController 통합 테스트")
 class DailyMessageCommentControllerTest : BaseControllerTest() {
@@ -39,7 +38,7 @@ class DailyMessageCommentControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -100,7 +99,7 @@ class DailyMessageCommentControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/dailymessage/DailyMessageCommentControllerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
+import com.example.mykku.role.domain.Role
 
 @DisplayName("DailyMessageCommentController 통합 테스트")
 class DailyMessageCommentControllerTest : BaseControllerTest() {
@@ -38,7 +39,7 @@ class DailyMessageCommentControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -99,7 +100,7 @@ class DailyMessageCommentControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
@@ -181,8 +181,8 @@ class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
                     responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
                             .description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NULL)
-                            .description("응답 데이터 (없음)")
+                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("응답 데이터 (없음)").optional()
                     )
                 )
             )
@@ -196,7 +196,6 @@ class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
             email = "test@example.com",
             password = "password",
             nickname = "덕후왕",
-            defaultRole = role
         )
         val memberRole = MemberRole(id = 1L, member = member, role = role)
         val response = MemberRoleResponse(memberRole, member)

--- a/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
@@ -1,0 +1,239 @@
+package com.example.mykku.docs
+
+import com.example.mykku.BaseControllerRestDocsTest
+import com.example.mykku.admin.controller.AdminRoleApiController
+import com.example.mykku.admin.service.AdminRoleService
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.dto.CreateRoleRequest
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.example.mykku.role.dto.RoleResponse
+import com.example.mykku.role.dto.UpdateRoleRequest
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
+
+    @Mock
+    private lateinit var adminRoleService: AdminRoleService
+
+    @InjectMocks
+    private lateinit var adminRoleApiController: AdminRoleApiController
+
+    override fun createMockMvcBuilder(): StandaloneMockMvcBuilder {
+        return MockMvcBuilders.standaloneSetup(adminRoleApiController)
+    }
+
+    @Test
+    fun `칭호 목록 조회 API 문서화`() {
+        val roles = listOf(
+            RoleResponse(Role(id = 1L, name = "신입 덕후", description = "처음 가입한 회원")),
+            RoleResponse(Role(id = 2L, name = "열정 덕후", description = "활동이 활발한 회원")),
+            RoleResponse(Role(id = 3L, name = "베테랑 덕후", description = "오래된 회원"))
+        )
+
+        whenever(adminRoleService.getAllRoles()).thenReturn(roles)
+
+        mockMvc.perform(
+            get("/admin/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 목록 조회 성공"))
+            .andDo(
+                document(
+                    "admin-role-get-all",
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.ARRAY)
+                            .description("칭호 목록"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
+                            .description("칭호 ID"),
+                        fieldWithPath("data[].name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("data[].description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional()
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `칭호 생성 API 문서화`() {
+        val request = CreateRoleRequest(
+            name = "슈퍼 덕후",
+            description = "최고 등급 회원"
+        )
+        val response = RoleResponse(
+            Role(id = 1L, name = "슈퍼 덕후", description = "최고 등급 회원")
+        )
+
+        whenever(adminRoleService.createRole(any<CreateRoleRequest>())).thenReturn(response)
+
+        mockMvc.perform(
+            post("/admin/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("칭호 생성 성공"))
+            .andDo(
+                document(
+                    "admin-role-create",
+                    requestFields(
+                        fieldWithPath("name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional()
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("생성된 칭호 정보"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                            .description("칭호 ID"),
+                        fieldWithPath("data.name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("data.description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional()
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `칭호 수정 API 문서화`() {
+        val request = UpdateRoleRequest(
+            name = "수정된 덕후",
+            description = "수정된 설명"
+        )
+        val response = RoleResponse(
+            Role(id = 1L, name = "수정된 덕후", description = "수정된 설명")
+        )
+
+        whenever(adminRoleService.updateRole(any<Long>(), any<UpdateRoleRequest>())).thenReturn(response)
+
+        mockMvc.perform(
+            put("/admin/api/v1/roles/{roleId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 수정 성공"))
+            .andDo(
+                document(
+                    "admin-role-update",
+                    pathParameters(
+                        parameterWithName("roleId").description("수정할 칭호 ID")
+                    ),
+                    requestFields(
+                        fieldWithPath("name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional()
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("수정된 칭호 정보"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                            .description("칭호 ID"),
+                        fieldWithPath("data.name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("data.description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional()
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `칭호 삭제 API 문서화`() {
+        mockMvc.perform(
+            delete("/admin/api/v1/roles/{roleId}", 1L)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("칭호 삭제 성공"))
+            .andDo(
+                document(
+                    "admin-role-delete",
+                    pathParameters(
+                        parameterWithName("roleId").description("삭제할 칭호 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.NULL)
+                            .description("응답 데이터 (없음)")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `회원에게 칭호 부여 API 문서화`() {
+        val role = Role(id = 1L, name = "열정 덕후", description = "활동이 활발한 회원")
+        val member = Member.createEmailMember(
+            id = "member-123",
+            email = "test@example.com",
+            password = "password",
+            nickname = "덕후왕",
+            defaultRole = role
+        )
+        val memberRole = MemberRole(id = 1L, member = member, role = role)
+        val response = MemberRoleResponse(memberRole, member)
+
+        whenever(adminRoleService.assignRoleToMember(any<Long>(), any<String>())).thenReturn(response)
+
+        mockMvc.perform(
+            post("/admin/api/v1/roles/{roleId}/members/{memberId}", 1L, "member-123")
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("칭호 부여 성공"))
+            .andDo(
+                document(
+                    "admin-role-assign",
+                    pathParameters(
+                        parameterWithName("roleId").description("부여할 칭호 ID"),
+                        parameterWithName("memberId").description("칭호를 부여받을 회원 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("부여된 칭호 정보"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                            .description("보유 칭호 ID"),
+                        fieldWithPath("data.role").type(JsonFieldType.OBJECT)
+                            .description("칭호 정보"),
+                        fieldWithPath("data.role.id").type(JsonFieldType.NUMBER)
+                            .description("칭호 ID"),
+                        fieldWithPath("data.role.name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("data.role.description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional(),
+                        fieldWithPath("data.assignedAt").type(JsonFieldType.STRING)
+                            .description("칭호 부여 일시")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/AdminRoleApiControllerRestDocsTest.kt
@@ -3,6 +3,7 @@ package com.example.mykku.docs
 import com.example.mykku.BaseControllerRestDocsTest
 import com.example.mykku.admin.controller.AdminRoleApiController
 import com.example.mykku.admin.service.AdminRoleService
+import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import com.example.mykku.role.domain.MemberRole
 import com.example.mykku.role.domain.Role
@@ -26,6 +27,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import java.time.LocalDateTime
 
 class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
 
@@ -197,7 +199,11 @@ class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
             password = "password",
             nickname = "덕후왕",
         )
-        val memberRole = MemberRole(id = 1L, member = member, role = role)
+        val memberRole = MemberRole(id = 1L, member = member, role = role).apply {
+            val field = BaseEntity::class.java.getDeclaredField("createdAt")
+            field.isAccessible = true
+            field.set(this, LocalDateTime.now())
+        }
         val response = MemberRoleResponse(memberRole, member)
 
         whenever(adminRoleService.assignRoleToMember(any<Long>(), any<String>())).thenReturn(response)
@@ -229,8 +235,10 @@ class AdminRoleApiControllerRestDocsTest : BaseControllerRestDocsTest() {
                             .description("칭호 이름"),
                         fieldWithPath("data.role.description").type(JsonFieldType.STRING)
                             .description("칭호 설명").optional(),
-                        fieldWithPath("data.assignedAt").type(JsonFieldType.STRING)
-                            .description("칭호 부여 일시")
+                        fieldWithPath("data.earnedAt").type(JsonFieldType.STRING)
+                            .description("칭호 부여 일시"),
+                        fieldWithPath("data.isRepresentative").type(JsonFieldType.BOOLEAN)
+                            .description("대표 칭호 여부")
                     )
                 )
             )

--- a/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/FeedControllerRestDocsTest.kt
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 import java.time.LocalDateTime
+import com.example.mykku.role.domain.Role
 
 class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
 
@@ -57,7 +58,7 @@ class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
                         memberId = memberId,
                         nickname = "닉네임1",
                         profileImage = "https://example.com/profile1.jpg",
-                        role = "USER"
+                        role = "일반 덕후"
                     ),
                     board = "자유게시판",
                     createdAt = LocalDateTime.of(2024, 1, 1, 12, 0),
@@ -94,7 +95,7 @@ class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
                         memberId = memberId,
                         nickname = "닉네임2",
                         profileImage = "https://example.com/profile2.jpg",
-                        role = "USER"
+                        role = "일반 덕후"
                     ),
                     board = "질문게시판",
                     createdAt = LocalDateTime.of(2024, 1, 2, 13, 30),
@@ -442,7 +443,7 @@ class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
                         memberId = "member1",
                         nickname = "닉네임1",
                         profileImage = "https://example.com/profile1.jpg",
-                        role = "USER"
+                        role = "일반 덕후"
                     ),
                     board = "자유게시판",
                     createdAt = LocalDateTime.of(2024, 1, 1, 12, 0),
@@ -555,7 +556,7 @@ class FeedControllerRestDocsTest : BaseControllerRestDocsTest() {
                 memberId = "member1",
                 nickname = "작성자닉네임",
                 profileImage = "https://example.com/profile.jpg",
-                role = "USER"
+                role = "일반 덕후"
             ),
             boardId = 1L,
             boardTitle = "자유게시판",

--- a/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
@@ -1,0 +1,117 @@
+package com.example.mykku.docs
+
+import com.example.mykku.BaseControllerRestDocsTest
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.RoleController
+import com.example.mykku.role.RoleService
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.dto.MemberRoleResponse
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
+
+    @Mock
+    private lateinit var roleService: RoleService
+
+    @InjectMocks
+    private lateinit var roleController: RoleController
+
+    override fun createMockMvcBuilder(): StandaloneMockMvcBuilder {
+        return MockMvcBuilders.standaloneSetup(roleController)
+    }
+
+    @Test
+    fun `내 칭호 목록 조회 API 문서화`() {
+        val role1 = Role(id = 1L, name = "신입 덕후", description = "처음 가입한 회원")
+        val role2 = Role(id = 2L, name = "열정 덕후", description = "활동이 활발한 회원")
+        val member = Member.createEmailMember(
+            id = "member-123",
+            email = "test@example.com",
+            password = "password",
+            nickname = "덕후왕",
+            defaultRole = role1
+        )
+
+        val memberRole1 = MemberRole(id = 1L, member = member, role = role1)
+        val memberRole2 = MemberRole(id = 2L, member = member, role = role2)
+        val memberRoles = listOf(
+            MemberRoleResponse(memberRole1, member),
+            MemberRoleResponse(memberRole2, member)
+        )
+
+        whenever(roleService.getMyRoles(any<Member>())).thenReturn(memberRoles)
+
+        mockMvc.perform(
+            get("/api/v1/roles/me")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("내 칭호 목록 조회 성공"))
+            .andExpect(jsonPath("$.data").isArray)
+            .andDo(
+                document(
+                    "role-get-my-roles",
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.ARRAY)
+                            .description("칭호 목록"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
+                            .description("보유 칭호 ID"),
+                        fieldWithPath("data[].role").type(JsonFieldType.OBJECT)
+                            .description("칭호 정보"),
+                        fieldWithPath("data[].role.id").type(JsonFieldType.NUMBER)
+                            .description("칭호 ID"),
+                        fieldWithPath("data[].role.name").type(JsonFieldType.STRING)
+                            .description("칭호 이름"),
+                        fieldWithPath("data[].role.description").type(JsonFieldType.STRING)
+                            .description("칭호 설명").optional(),
+                        fieldWithPath("data[].assignedAt").type(JsonFieldType.STRING)
+                            .description("칭호 획득 일시")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `대표 칭호 변경 API 문서화`() {
+        mockMvc.perform(
+            patch("/api/v1/roles/{memberRoleId}/representative", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("대표 칭호 변경 성공"))
+            .andDo(
+                document(
+                    "role-change-representative",
+                    pathParameters(
+                        parameterWithName("memberRoleId").description("대표로 설정할 보유 칭호 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.NULL)
+                            .description("응답 데이터 (없음)")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
@@ -1,6 +1,7 @@
 package com.example.mykku.docs
 
 import com.example.mykku.BaseControllerRestDocsTest
+import com.example.mykku.common.domain.BaseEntity
 import com.example.mykku.member.domain.Member
 import com.example.mykku.role.RoleController
 import com.example.mykku.role.RoleService
@@ -25,6 +26,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import java.time.LocalDateTime
 
 class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
 
@@ -49,8 +51,16 @@ class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
             nickname = "덕후왕",
         )
 
-        val memberRole1 = MemberRole(id = 1L, member = member, role = role1)
-        val memberRole2 = MemberRole(id = 2L, member = member, role = role2)
+        val memberRole1 = MemberRole(id = 1L, member = member, role = role1).apply {
+            val field = BaseEntity::class.java.getDeclaredField("createdAt")
+            field.isAccessible = true
+            field.set(this, LocalDateTime.now())
+        }
+        val memberRole2 = MemberRole(id = 2L, member = member, role = role2).apply {
+            val field = BaseEntity::class.java.getDeclaredField("createdAt")
+            field.isAccessible = true
+            field.set(this, LocalDateTime.now())
+        }
         val memberRoles = listOf(
             MemberRoleResponse(memberRole1, member),
             MemberRoleResponse(memberRole2, member)
@@ -83,8 +93,10 @@ class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
                             .description("칭호 이름"),
                         fieldWithPath("data[].role.description").type(JsonFieldType.STRING)
                             .description("칭호 설명").optional(),
-                        fieldWithPath("data[].assignedAt").type(JsonFieldType.STRING)
-                            .description("칭호 획득 일시")
+                        fieldWithPath("data[].earnedAt").type(JsonFieldType.STRING)
+                            .description("칭호 획득 일시"),
+                        fieldWithPath("data[].isRepresentative").type(JsonFieldType.BOOLEAN)
+                            .description("대표 칭호 여부")
                     )
                 )
             )

--- a/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
+++ b/src/test/kotlin/com/example/mykku/docs/RoleControllerRestDocsTest.kt
@@ -47,7 +47,6 @@ class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
             email = "test@example.com",
             password = "password",
             nickname = "덕후왕",
-            defaultRole = role1
         )
 
         val memberRole1 = MemberRole(id = 1L, member = member, role = role1)
@@ -108,8 +107,8 @@ class RoleControllerRestDocsTest : BaseControllerRestDocsTest() {
                     responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
                             .description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NULL)
-                            .description("응답 데이터 (없음)")
+                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("응답 데이터 (없음)").optional()
                     )
                 )
             )

--- a/src/test/kotlin/com/example/mykku/email/EmailAuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/email/EmailAuthControllerTest.kt
@@ -5,6 +5,7 @@ import com.example.mykku.email.domain.VerificationPurpose
 import com.example.mykku.email.dto.*
 import com.example.mykku.email.tool.RedisVerificationCodeManager
 import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.Role
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
 import org.hamcrest.Matchers.equalTo
@@ -51,11 +52,14 @@ class EmailAuthControllerTest : BaseControllerTest() {
     @DisplayName("인증 코드 발송 - 이미 존재하는 이메일로 회원가입 시도")
     fun `sendVerificationCode - 이미 존재하는 이메일로 회원가입 인증 코드 발송 시 실패`() {
         val existingEmail = "existing@example.com"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = Member.createEmailMember(
             id = "existingMember",
             email = existingEmail,
             password = "password",
-            nickname = "기존유저"
+            nickname = "기존유저",
+            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -187,11 +191,14 @@ class EmailAuthControllerTest : BaseControllerTest() {
     @DisplayName("회원가입 - 이미 존재하는 이메일")
     fun `signup - 이미 존재하는 이메일로 회원가입 시 실패`() {
         val existingEmail = "existing@example.com"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = Member.createEmailMember(
             id = "existingMember",
             email = existingEmail,
             password = "password",
-            nickname = "기존유저"
+            nickname = "기존유저",
+            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -234,11 +241,14 @@ class EmailAuthControllerTest : BaseControllerTest() {
     fun `login - 이메일 로그인 성공`() {
         val email = "user@example.com"
         val password = "password123!"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = Member.createEmailMember(
             id = "loginMember",
             email = email,
             password = passwordEncoder.encode(password),
-            nickname = "로그인유저"
+            nickname = "로그인유저",
+            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -281,11 +291,14 @@ class EmailAuthControllerTest : BaseControllerTest() {
     @DisplayName("로그인 - 잘못된 비밀번호")
     fun `login - 잘못된 비밀번호로 로그인 시 실패`() {
         val email = "user@example.com"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = Member.createEmailMember(
             id = "wrongPasswordMember",
             email = email,
             password = passwordEncoder.encode("correctPassword123!"),
-            nickname = "유저"
+            nickname = "유저",
+            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -308,11 +321,14 @@ class EmailAuthControllerTest : BaseControllerTest() {
     @DisplayName("비밀번호 재설정 - 성공")
     fun `resetPassword - 비밀번호 재설정 성공`() {
         val email = "reset@example.com"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
         val member = Member.createEmailMember(
             id = "resetMember",
             email = email,
             password = passwordEncoder.encode("oldPassword123!"),
-            nickname = "재설정유저"
+            nickname = "재설정유저",
+            defaultRole = role
         )
         memberRepository.save(member)
 

--- a/src/test/kotlin/com/example/mykku/email/EmailAuthControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/email/EmailAuthControllerTest.kt
@@ -59,7 +59,6 @@ class EmailAuthControllerTest : BaseControllerTest() {
             email = existingEmail,
             password = "password",
             nickname = "기존유저",
-            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -198,7 +197,6 @@ class EmailAuthControllerTest : BaseControllerTest() {
             email = existingEmail,
             password = "password",
             nickname = "기존유저",
-            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -248,7 +246,6 @@ class EmailAuthControllerTest : BaseControllerTest() {
             email = email,
             password = passwordEncoder.encode(password),
             nickname = "로그인유저",
-            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -298,7 +295,6 @@ class EmailAuthControllerTest : BaseControllerTest() {
             email = email,
             password = passwordEncoder.encode("correctPassword123!"),
             nickname = "유저",
-            defaultRole = role
         )
         memberRepository.save(member)
 
@@ -328,7 +324,6 @@ class EmailAuthControllerTest : BaseControllerTest() {
             email = email,
             password = passwordEncoder.encode("oldPassword123!"),
             nickname = "재설정유저",
-            defaultRole = role
         )
         memberRepository.save(member)
 

--- a/src/test/kotlin/com/example/mykku/email/EmailAuthServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/email/EmailAuthServiceTest.kt
@@ -45,6 +45,12 @@ class EmailAuthServiceTest : BaseServiceTest() {
     @Mock
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
+    @Mock
+    private lateinit var roleReader: com.example.mykku.role.tool.RoleReader
+
+    @Mock
+    private lateinit var memberRoleWriter: com.example.mykku.role.tool.MemberRoleWriter
+
     @InjectMocks
     private lateinit var emailAuthService: EmailAuthService
 
@@ -142,13 +148,11 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val password = "password123!"
         val nickname = "테스트"
         val encodedPassword = "encodedPassword"
-        val role = Role(name = "일반 덕후", description = "테스트용 칭호")
         val member = Member.createEmailMember(
             id = "memberId",
             email = email,
             password = encodedPassword,
-            nickname = nickname,
-            defaultRole = role
+            nickname = nickname
         )
         val loginResponse = LoginResponse(
             accessToken = "accessToken",

--- a/src/test/kotlin/com/example/mykku/email/EmailAuthServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/email/EmailAuthServiceTest.kt
@@ -13,6 +13,7 @@ import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
 import com.example.mykku.member.tool.MemberReader
 import com.example.mykku.member.tool.MemberWriter
+import com.example.mykku.role.domain.Role
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -141,11 +142,13 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val password = "password123!"
         val nickname = "테스트"
         val encodedPassword = "encodedPassword"
+        val role = Role(name = "일반 덕후", description = "테스트용 칭호")
         val member = Member.createEmailMember(
             id = "memberId",
             email = email,
             password = encodedPassword,
-            nickname = nickname
+            nickname = nickname,
+            defaultRole = role
         )
         val loginResponse = LoginResponse(
             accessToken = "accessToken",
@@ -196,10 +199,11 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val email = "test@example.com"
         val password = "password123!"
         val encodedPassword = "encodedPassword"
+        val role = Role(name = "일반 덕후", description = "테스트용 칭호")
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = role,
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -255,7 +259,7 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -282,7 +286,7 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -346,7 +350,7 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -385,7 +389,7 @@ class EmailAuthServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,

--- a/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
@@ -15,7 +15,6 @@ import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import com.example.mykku.role.domain.Role
 
 @DisplayName("FeedController 통합 테스트")
 class FeedControllerTest : BaseControllerTest() {
@@ -34,7 +33,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -108,7 +107,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -148,7 +147,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -193,7 +192,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -235,7 +234,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -288,7 +287,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -333,7 +332,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -376,7 +375,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/FeedControllerTest.kt
@@ -15,6 +15,7 @@ import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import com.example.mykku.role.domain.Role
 
 @DisplayName("FeedController 통합 테스트")
 class FeedControllerTest : BaseControllerTest() {
@@ -33,7 +34,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -107,7 +108,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -147,7 +148,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -192,7 +193,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -234,7 +235,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -287,7 +288,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -332,7 +333,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -375,7 +376,7 @@ class FeedControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/feed/FeedServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/FeedServiceTest.kt
@@ -35,6 +35,7 @@ import org.springframework.web.multipart.MultipartFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import com.example.mykku.role.domain.Role
 
 class FeedServiceTest : BaseServiceTest() {
 
@@ -293,7 +294,7 @@ class FeedServiceTest : BaseServiceTest() {
         val followingMember = Member(
             id = "member2",
             nickname = "following",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.GOOGLE,
             socialId = "456",
@@ -302,7 +303,7 @@ class FeedServiceTest : BaseServiceTest() {
         val recommendedMember = Member(
             id = "member3",
             nickname = "recommend",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.GOOGLE,
             socialId = "789",
@@ -573,7 +574,7 @@ class FeedServiceTest : BaseServiceTest() {
         val recommendedMember = Member(
             id = "member2",
             nickname = "recommend",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.GOOGLE,
             socialId = "789",

--- a/src/test/kotlin/com/example/mykku/feed/domain/FeedTagTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/domain/FeedTagTest.kt
@@ -8,6 +8,7 @@ import com.example.mykku.member.domain.SocialProvider
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
+import com.example.mykku.role.domain.Role
 
 class FeedTagTest {
 
@@ -15,7 +16,7 @@ class FeedTagTest {
         val member = Member(
             id = "test_member",
             nickname = "테스트유저",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",

--- a/src/test/kotlin/com/example/mykku/feed/domain/FeedTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/domain/FeedTest.kt
@@ -8,6 +8,7 @@ import com.example.mykku.member.domain.SocialProvider
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
+import com.example.mykku.role.domain.Role
 
 class FeedTest {
 
@@ -15,7 +16,7 @@ class FeedTest {
         val member = Member(
             id = "test_member",
             nickname = "테스트유저",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",

--- a/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/feed/repository/EventRepositoryTest.kt
@@ -4,12 +4,10 @@ import com.example.mykku.BaseRepositoryTest
 import com.example.mykku.feed.domain.Event
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-import com.example.mykku.feed.domain.EventSortType
-import org.springframework.data.domain.PageRequest
 
 class EventRepositoryTest : BaseRepositoryTest() {
 

--- a/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.LocalDateTime
-import com.example.mykku.role.domain.Role
 
 @DisplayName("HomeController 통합 테스트")
 class HomeControllerTest : BaseControllerTest() {
@@ -53,7 +52,7 @@ class HomeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/home/HomeControllerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.LocalDateTime
+import com.example.mykku.role.domain.Role
 
 @DisplayName("HomeController 통합 테스트")
 class HomeControllerTest : BaseControllerTest() {
@@ -52,7 +53,7 @@ class HomeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
@@ -11,7 +11,6 @@ import io.restassured.http.ContentType
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import com.example.mykku.role.domain.Role
 
 @DisplayName("LikeController 통합 테스트")
 class LikeControllerTest : BaseControllerTest() {
@@ -27,7 +26,7 @@ class LikeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )
@@ -66,7 +65,7 @@ class LikeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
+                role = null,
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/like/LikeControllerTest.kt
@@ -11,6 +11,7 @@ import io.restassured.http.ContentType
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import com.example.mykku.role.domain.Role
 
 @DisplayName("LikeController 통합 테스트")
 class LikeControllerTest : BaseControllerTest() {
@@ -26,7 +27,7 @@ class LikeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )
@@ -65,7 +66,7 @@ class LikeControllerTest : BaseControllerTest() {
                 provider = SocialProvider.GOOGLE,
                 email = "member1@example.com",
                 nickname = "Member1",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = ""
             )
         )

--- a/src/test/kotlin/com/example/mykku/member/MemberServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/member/MemberServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.Mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.crypto.password.PasswordEncoder
+import com.example.mykku.role.domain.Role
 
 class MemberServiceTest : BaseServiceTest() {
 
@@ -35,7 +36,7 @@ class MemberServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -62,7 +63,7 @@ class MemberServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,
@@ -86,7 +87,7 @@ class MemberServiceTest : BaseServiceTest() {
         val member = Member(
             id = "memberId",
             nickname = "테스트",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "",
             provider = SocialProvider.EMAIL,
             socialId = null,

--- a/src/test/kotlin/com/example/mykku/member/domain/MemberTest.kt
+++ b/src/test/kotlin/com/example/mykku/member/domain/MemberTest.kt
@@ -5,6 +5,7 @@ import com.example.mykku.member.exception.MemberErrorCode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
+import com.example.mykku.role.domain.Role
 
 class MemberTest {
 
@@ -15,7 +16,7 @@ class MemberTest {
         Member(
             id = "test_member",
             nickname = validNickname,
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -31,7 +32,7 @@ class MemberTest {
             Member(
                 id = "test_member",
                 nickname = invalidNickname,
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = "profile.jpg",
                 provider = SocialProvider.GOOGLE,
                 socialId = "12345",
@@ -47,7 +48,7 @@ class MemberTest {
         Member(
             id = "test_member",
             nickname = "한글123",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -57,7 +58,7 @@ class MemberTest {
         Member(
             id = "test_member2",
             nickname = "English123",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -67,7 +68,7 @@ class MemberTest {
         Member(
             id = "test_member3",
             nickname = "123456",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -81,7 +82,7 @@ class MemberTest {
             Member(
                 id = "test_member",
                 nickname = "닉네임!",
-                role = "USER",
+                role = Role(name = "일반 덕후", description = "테스트용 칭호"),
                 profileImage = "profile.jpg",
                 provider = SocialProvider.GOOGLE,
                 socialId = "12345",

--- a/src/test/kotlin/com/example/mykku/member/repository/MemberRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/member/repository/MemberRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.example.mykku.member.repository
 import com.example.mykku.BaseRepositoryTest
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
-import com.example.mykku.role.domain.Role
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -52,15 +51,12 @@ class MemberRepositoryTest : BaseRepositoryTest() {
     @Test
     fun `이메일 회원과 소셜 회원이 다른 이메일을 가진 경우 구분됨`() {
         val email = "test@example.com"
-        val role = roleRepository.findByName("일반 덕후")
-            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
 
         val emailMember = Member.createEmailMember(
             id = "emailMember",
             email = email,
             password = "password",
-            nickname = "이메일유저",
-            defaultRole = role
+            nickname = "이메일유저"
         )
         val socialMember = Member.createSocialMember(
             id = "socialMember",
@@ -68,8 +64,7 @@ class MemberRepositoryTest : BaseRepositoryTest() {
             nickname = "소셜유저",
             profileImage = "",
             provider = SocialProvider.GOOGLE,
-            socialId = "12345",
-            defaultRole = role
+            socialId = "12345"
         )
 
         memberRepository.save(emailMember)

--- a/src/test/kotlin/com/example/mykku/member/repository/MemberRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/member/repository/MemberRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.example.mykku.member.repository
 import com.example.mykku.BaseRepositoryTest
 import com.example.mykku.member.domain.Member
 import com.example.mykku.member.domain.SocialProvider
+import com.example.mykku.role.domain.Role
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -51,11 +52,15 @@ class MemberRepositoryTest : BaseRepositoryTest() {
     @Test
     fun `이메일 회원과 소셜 회원이 다른 이메일을 가진 경우 구분됨`() {
         val email = "test@example.com"
+        val role = roleRepository.findByName("일반 덕후")
+            ?: roleRepository.save(Role(name = "일반 덕후", description = "테스트용 칭호"))
+
         val emailMember = Member.createEmailMember(
             id = "emailMember",
             email = email,
             password = "password",
-            nickname = "이메일유저"
+            nickname = "이메일유저",
+            defaultRole = role
         )
         val socialMember = Member.createSocialMember(
             id = "socialMember",
@@ -63,7 +68,8 @@ class MemberRepositoryTest : BaseRepositoryTest() {
             nickname = "소셜유저",
             profileImage = "",
             provider = SocialProvider.GOOGLE,
-            socialId = "12345"
+            socialId = "12345",
+            defaultRole = role
         )
 
         memberRepository.save(emailMember)

--- a/src/test/kotlin/com/example/mykku/member/tool/MemberWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/member/tool/MemberWriterTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
+import com.example.mykku.role.domain.Role
 
 class MemberWriterTest : BaseToolTest() {
 
@@ -25,7 +26,7 @@ class MemberWriterTest : BaseToolTest() {
         val member = Member(
             id = "member123",
             nickname = "테스트유저",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -34,7 +35,7 @@ class MemberWriterTest : BaseToolTest() {
         val savedMember = Member(
             id = "member123",
             nickname = "테스트유저",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -57,7 +58,7 @@ class MemberWriterTest : BaseToolTest() {
         val existingMember = Member(
             id = "member123",
             nickname = "기존닉네임",
-            role = "USER",
+            role = Role(name = "일반 덕후", description = "테스트용 칭호"),
             profileImage = "old_profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",
@@ -66,7 +67,7 @@ class MemberWriterTest : BaseToolTest() {
         val updatedMember = Member(
             id = "member123",
             nickname = "새로운닉네임",
-            role = "ADMIN",
+            role = Role(name = "관리자", description = "테스트용 칭호"),
             profileImage = "new_profile.jpg",
             provider = SocialProvider.GOOGLE,
             socialId = "12345",

--- a/src/test/kotlin/com/example/mykku/role/RoleControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/RoleControllerTest.kt
@@ -1,0 +1,84 @@
+package com.example.mykku.role
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.dto.MemberRoleResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(RoleController::class)
+class RoleControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var roleService: RoleService
+
+    private lateinit var member: Member
+    private lateinit var role: Role
+
+    @BeforeEach
+    fun setUp() {
+        role = Role(id = 1L, name = "테스트 칭호", description = "설명")
+        member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role
+        )
+    }
+
+    @Test
+    @WithMockUser
+    fun `내 칭호 목록을 조회할 수 있다`() {
+        val role2 = Role(id = 2L, name = "다른 칭호", description = "")
+        val memberRole1 = MemberRole(id = 1L, member = member, role = role)
+        val memberRole2 = MemberRole(id = 2L, member = member, role = role2)
+        val memberRoles = listOf(
+            MemberRoleResponse(memberRole1, member),
+            MemberRoleResponse(memberRole2, member)
+        )
+        whenever(roleService.getMyRoles(any<Member>())).thenReturn(memberRoles)
+
+        mockMvc.perform(
+            get("/api/v1/roles/me")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("내 칭호 목록 조회 성공"))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(2))
+    }
+
+    @Test
+    @WithMockUser
+    fun `대표 칭호를 변경할 수 있다`() {
+        mockMvc.perform(
+            patch("/api/v1/roles/1/representative")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("대표 칭호 변경 성공"))
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/RoleControllerTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/RoleControllerTest.kt
@@ -1,84 +1,80 @@
 package com.example.mykku.role
 
-import com.example.mykku.member.domain.Member
+import com.example.mykku.BaseControllerTest
 import com.example.mykku.role.domain.MemberRole
 import com.example.mykku.role.domain.Role
-import com.example.mykku.role.dto.MemberRoleResponse
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.example.mykku.role.repository.MemberRoleRepository
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.MediaType
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest(RoleController::class)
-class RoleControllerTest {
+@DisplayName("RoleController 통합 테스트")
+class RoleControllerTest : BaseControllerTest() {
 
     @Autowired
-    private lateinit var mockMvc: MockMvc
+    private lateinit var memberRoleRepository: MemberRoleRepository
 
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
-    @MockBean
-    private lateinit var roleService: RoleService
-
-    private lateinit var member: Member
-    private lateinit var role: Role
+    private lateinit var role1: Role
+    private lateinit var role2: Role
 
     @BeforeEach
     fun setUp() {
-        role = Role(id = 1L, name = "테스트 칭호", description = "설명")
-        member = Member.createEmailMember(
-            id = "test-id",
-            email = "test@example.com",
-            password = "password",
+        role1 = roleRepository.save(Role(name = "칭호1", description = "설명1"))
+        role2 = roleRepository.save(Role(name = "칭호2", description = "설명2"))
+    }
+
+    @Test
+    @DisplayName("내 칭호 목록을 조회할 수 있다")
+    fun `getMyRoles - 내 칭호 목록을 조회한다`() {
+        // given
+        val member = createAndSaveMember(
+            id = "test-member",
             nickname = "테스터",
-            defaultRole = role
+            role = role1
         )
+        memberRoleRepository.save(MemberRole(member = member, role = role1))
+        memberRoleRepository.save(MemberRole(member = member, role = role2))
+
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .headers(createAuthHeaders(member.id))
+            .`when`()
+                .get("/api/v1/roles/me")
+            .then()
+                .statusCode(200)
+                .body("message", equalTo("내 칭호 목록 조회 성공"))
+                .body("data", hasSize<Any>(2))
+                .body("data[0].role.name", notNullValue())
+                .body("data[0].isRepresentative", notNullValue())
     }
 
     @Test
-    @WithMockUser
-    fun `내 칭호 목록을 조회할 수 있다`() {
-        val role2 = Role(id = 2L, name = "다른 칭호", description = "")
-        val memberRole1 = MemberRole(id = 1L, member = member, role = role)
-        val memberRole2 = MemberRole(id = 2L, member = member, role = role2)
-        val memberRoles = listOf(
-            MemberRoleResponse(memberRole1, member),
-            MemberRoleResponse(memberRole2, member)
+    @DisplayName("대표 칭호를 변경할 수 있다")
+    fun `changeRepresentativeRole - 대표 칭호를 변경한다`() {
+        // given
+        val member = createAndSaveMember(
+            id = "test-member",
+            nickname = "테스터",
+            role = role1
         )
-        whenever(roleService.getMyRoles(any<Member>())).thenReturn(memberRoles)
+        val memberRole1 = memberRoleRepository.save(MemberRole(member = member, role = role1))
+        val memberRole2 = memberRoleRepository.save(MemberRole(member = member, role = role2))
 
-        mockMvc.perform(
-            get("/api/v1/roles/me")
-                .contentType(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("내 칭호 목록 조회 성공"))
-            .andExpect(jsonPath("$.data").isArray)
-            .andExpect(jsonPath("$.data.length()").value(2))
-    }
-
-    @Test
-    @WithMockUser
-    fun `대표 칭호를 변경할 수 있다`() {
-        mockMvc.perform(
-            patch("/api/v1/roles/1/representative")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(csrf())
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("대표 칭호 변경 성공"))
+        // when & then
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .headers(createAuthHeaders(member.id))
+            .`when`()
+                .patch("/api/v1/roles/${memberRole2.id}/representative")
+            .then()
+                .statusCode(200)
+                .body("message", equalTo("대표 칭호 변경 성공"))
     }
 }

--- a/src/test/kotlin/com/example/mykku/role/RoleServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/RoleServiceTest.kt
@@ -7,7 +7,6 @@ import com.example.mykku.role.domain.Role
 import com.example.mykku.role.exception.RoleErrorCode
 import com.example.mykku.role.exception.RoleException
 import com.example.mykku.role.tool.MemberRoleReader
-import com.example.mykku.role.tool.MemberRoleWriter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,9 +23,6 @@ class RoleServiceTest {
 
     @Mock
     private lateinit var memberRoleReader: MemberRoleReader
-
-    @Mock
-    private lateinit var memberRoleWriter: MemberRoleWriter
 
     @Mock
     private lateinit var memberWriter: MemberWriter
@@ -46,17 +42,24 @@ class RoleServiceTest {
             id = "test-id",
             email = "test@example.com",
             password = "password",
-            nickname = "테스터",
-            defaultRole = role1
+            nickname = "테스터"
         )
+        member.role = role1
     }
 
     @Test
     fun `내 칭호 목록을 조회할 수 있다`() {
-        val memberRoles = listOf(
-            MemberRole(id = 1L, member = member, role = role1),
-            MemberRole(id = 2L, member = member, role = role2)
-        )
+        val memberRole1 = org.mockito.kotlin.mock<MemberRole>()
+        whenever(memberRole1.id).thenReturn(1L)
+        whenever(memberRole1.role).thenReturn(role1)
+        whenever(memberRole1.createdAt).thenReturn(java.time.LocalDateTime.now())
+
+        val memberRole2 = org.mockito.kotlin.mock<MemberRole>()
+        whenever(memberRole2.id).thenReturn(2L)
+        whenever(memberRole2.role).thenReturn(role2)
+        whenever(memberRole2.createdAt).thenReturn(java.time.LocalDateTime.now())
+
+        val memberRoles = listOf(memberRole1, memberRole2)
         whenever(memberRoleReader.getMemberRolesByMember(member)).thenReturn(memberRoles)
 
         val result = roleService.getMyRoles(member)

--- a/src/test/kotlin/com/example/mykku/role/RoleServiceTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/RoleServiceTest.kt
@@ -1,0 +1,115 @@
+package com.example.mykku.role
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.tool.MemberWriter
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.tool.MemberRoleReader
+import com.example.mykku.role.tool.MemberRoleWriter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class RoleServiceTest {
+
+    @Mock
+    private lateinit var memberRoleReader: MemberRoleReader
+
+    @Mock
+    private lateinit var memberRoleWriter: MemberRoleWriter
+
+    @Mock
+    private lateinit var memberWriter: MemberWriter
+
+    @InjectMocks
+    private lateinit var roleService: RoleService
+
+    private lateinit var member: Member
+    private lateinit var role1: Role
+    private lateinit var role2: Role
+
+    @BeforeEach
+    fun setUp() {
+        role1 = Role(id = 1L, name = "칭호1", description = "설명1")
+        role2 = Role(id = 2L, name = "칭호2", description = "설명2")
+        member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role1
+        )
+    }
+
+    @Test
+    fun `내 칭호 목록을 조회할 수 있다`() {
+        val memberRoles = listOf(
+            MemberRole(id = 1L, member = member, role = role1),
+            MemberRole(id = 2L, member = member, role = role2)
+        )
+        whenever(memberRoleReader.getMemberRolesByMember(member)).thenReturn(memberRoles)
+
+        val result = roleService.getMyRoles(member)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.role.name }).contains("칭호1", "칭호2")
+        verify(memberRoleReader).getMemberRolesByMember(member)
+    }
+
+    @Test
+    fun `내 칭호가 없으면 빈 리스트를 반환한다`() {
+        whenever(memberRoleReader.getMemberRolesByMember(member)).thenReturn(emptyList())
+
+        val result = roleService.getMyRoles(member)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `대표 칭호를 변경할 수 있다`() {
+        val memberRole = MemberRole(id = 1L, member = member, role = role2)
+        whenever(memberRoleReader.getMemberRoleById(1L, member)).thenReturn(memberRole)
+
+        roleService.changeRepresentativeRole(member, 1L)
+
+        assertThat(member.role).isEqualTo(role2)
+        verify(memberRoleReader).getMemberRoleById(1L, member)
+        verify(memberWriter).save(member)
+    }
+
+    @Test
+    fun `보유하지 않은 칭호로 대표 칭호를 변경하려 하면 예외가 발생한다`() {
+        whenever(memberRoleReader.getMemberRoleById(999L, member)).thenThrow(
+            RoleException(RoleErrorCode.MEMBER_ROLE_NOT_FOUND)
+        )
+
+        val exception = assertThrows<RoleException> {
+            roleService.changeRepresentativeRole(member, 999L)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.MEMBER_ROLE_NOT_FOUND)
+    }
+
+    @Test
+    fun `다른 회원의 칭호로 대표 칭호를 변경하려 하면 예외가 발생한다`() {
+        whenever(memberRoleReader.getMemberRoleById(1L, member)).thenThrow(
+            RoleException(RoleErrorCode.MEMBER_ROLE_UNAUTHORIZED)
+        )
+
+        val exception = assertThrows<RoleException> {
+            roleService.changeRepresentativeRole(member, 1L)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.MEMBER_ROLE_UNAUTHORIZED)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/repository/MemberRoleRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/repository/MemberRoleRepositoryTest.kt
@@ -1,0 +1,164 @@
+package com.example.mykku.role.repository
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+@DataJpaTest
+class MemberRoleRepositoryTest {
+
+    @Autowired
+    private lateinit var memberRoleRepository: MemberRoleRepository
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var roleRepository: RoleRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+    private lateinit var member: Member
+    private lateinit var role1: Role
+    private lateinit var role2: Role
+
+    @BeforeEach
+    fun setUp() {
+        role1 = entityManager.persist(
+            Role(
+                name = "칭호1",
+                description = "첫 번째 칭호"
+            )
+        )
+        role2 = entityManager.persist(
+            Role(
+                name = "칭호2",
+                description = "두 번째 칭호"
+            )
+        )
+
+        member = Member.createEmailMember(
+            id = "test-member-id",
+            email = "test@example.com",
+            password = "encodedPassword",
+            nickname = "테스터",
+            defaultRole = role1
+        )
+        entityManager.persist(member)
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `회원의 칭호 목록을 조회할 수 있다`() {
+        val memberRole1 = entityManager.persist(
+            MemberRole(
+                member = member,
+                role = role1
+            )
+        )
+        val memberRole2 = entityManager.persist(
+            MemberRole(
+                member = member,
+                role = role2
+            )
+        )
+        entityManager.flush()
+        entityManager.clear()
+
+        val memberRoles = memberRoleRepository.findByMemberWithRole(member)
+
+        assertThat(memberRoles).hasSize(2)
+        assertThat(memberRoles.map { it.role.name }).contains("칭호1", "칭호2")
+    }
+
+    @Test
+    fun `회원의 칭호가 없으면 빈 리스트를 반환한다`() {
+        val memberRoles = memberRoleRepository.findByMemberWithRole(member)
+
+        assertThat(memberRoles).isEmpty()
+    }
+
+    @Test
+    fun `회원의 칭호를 저장할 수 있다`() {
+        val memberRole = MemberRole(
+            member = member,
+            role = role1
+        )
+
+        val saved = memberRoleRepository.save(memberRole)
+
+        assertThat(saved.id).isNotNull()
+        assertThat(saved.member.id).isEqualTo(member.id)
+        assertThat(saved.role.name).isEqualTo("칭호1")
+    }
+
+    @Test
+    fun `회원의 칭호를 삭제할 수 있다`() {
+        val memberRole = entityManager.persist(
+            MemberRole(
+                member = member,
+                role = role1
+            )
+        )
+        entityManager.flush()
+
+        memberRoleRepository.delete(memberRole)
+        entityManager.flush()
+
+        val memberRoles = memberRoleRepository.findByMemberWithRole(member)
+        assertThat(memberRoles).isEmpty()
+    }
+
+    @Test
+    fun `findByMemberWithRole은 JOIN FETCH로 Role을 함께 조회한다`() {
+        entityManager.persist(
+            MemberRole(
+                member = member,
+                role = role1
+            )
+        )
+        entityManager.flush()
+        entityManager.clear()
+
+        val memberRoles = memberRoleRepository.findByMemberWithRole(member)
+
+        assertThat(memberRoles).hasSize(1)
+        assertThat(memberRoles[0].role.name).isEqualTo("칭호1")
+    }
+
+    @Test
+    fun `회원과 칭호로 MemberRole을 조회할 수 있다`() {
+        val memberRole = entityManager.persist(
+            MemberRole(
+                member = member,
+                role = role1
+            )
+        )
+        entityManager.flush()
+        entityManager.clear()
+
+        val found = memberRoleRepository.findByMemberAndRole(member, role1)
+
+        assertThat(found).isNotNull
+        assertThat(found?.id).isEqualTo(memberRole.id)
+        assertThat(found?.member?.id).isEqualTo(member.id)
+        assertThat(found?.role?.name).isEqualTo("칭호1")
+    }
+
+    @Test
+    fun `존재하지 않는 회원-칭호 조합으로 조회하면 null을 반환한다`() {
+        val found = memberRoleRepository.findByMemberAndRole(member, role2)
+
+        assertThat(found).isNull()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/repository/MemberRoleRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/repository/MemberRoleRepositoryTest.kt
@@ -1,27 +1,19 @@
 package com.example.mykku.role.repository
 
+import com.example.mykku.BaseRepositoryTest
 import com.example.mykku.member.domain.Member
-import com.example.mykku.member.repository.MemberRepository
 import com.example.mykku.role.domain.MemberRole
 import com.example.mykku.role.domain.Role
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 
-@DataJpaTest
-class MemberRoleRepositoryTest {
+class MemberRoleRepositoryTest : BaseRepositoryTest() {
 
     @Autowired
     private lateinit var memberRoleRepository: MemberRoleRepository
-
-    @Autowired
-    private lateinit var memberRepository: MemberRepository
-
-    @Autowired
-    private lateinit var roleRepository: RoleRepository
 
     @Autowired
     private lateinit var entityManager: TestEntityManager
@@ -50,7 +42,6 @@ class MemberRoleRepositoryTest {
             email = "test@example.com",
             password = "encodedPassword",
             nickname = "테스터",
-            defaultRole = role1
         )
         entityManager.persist(member)
 

--- a/src/test/kotlin/com/example/mykku/role/repository/RoleRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/repository/RoleRepositoryTest.kt
@@ -1,18 +1,14 @@
 package com.example.mykku.role.repository
 
+import com.example.mykku.BaseRepositoryTest
 import com.example.mykku.role.domain.Role
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 
-@DataJpaTest
-class RoleRepositoryTest {
-
-    @Autowired
-    private lateinit var roleRepository: RoleRepository
+class RoleRepositoryTest : BaseRepositoryTest() {
 
     @Autowired
     private lateinit var entityManager: TestEntityManager

--- a/src/test/kotlin/com/example/mykku/role/repository/RoleRepositoryTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/repository/RoleRepositoryTest.kt
@@ -1,0 +1,103 @@
+package com.example.mykku.role.repository
+
+import com.example.mykku.role.domain.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+
+@DataJpaTest
+class RoleRepositoryTest {
+
+    @Autowired
+    private lateinit var roleRepository: RoleRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+    private lateinit var savedRole: Role
+
+    @BeforeEach
+    fun setUp() {
+        savedRole = entityManager.persist(
+            Role(
+                name = "테스트 칭호",
+                description = "테스트용 칭호입니다"
+            )
+        )
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `칭호 이름으로 칭호를 조회할 수 있다`() {
+        val found = roleRepository.findByName("테스트 칭호")
+
+        assertThat(found).isNotNull
+        assertThat(found?.name).isEqualTo("테스트 칭호")
+        assertThat(found?.description).isEqualTo("테스트용 칭호입니다")
+    }
+
+    @Test
+    fun `존재하지 않는 칭호 이름으로 조회하면 null을 반환한다`() {
+        val found = roleRepository.findByName("존재하지 않는 칭호")
+
+        assertThat(found).isNull()
+    }
+
+    @Test
+    fun `칭호 이름 존재 여부를 확인할 수 있다`() {
+        val exists = roleRepository.existsByName("테스트 칭호")
+        val notExists = roleRepository.existsByName("존재하지 않는 칭호")
+
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+
+    @Test
+    fun `칭호를 저장할 수 있다`() {
+        val newRole = Role(
+            name = "새로운 칭호",
+            description = "새로운 칭호 설명"
+        )
+
+        val saved = roleRepository.save(newRole)
+
+        assertThat(saved.id).isNotNull()
+        assertThat(saved.name).isEqualTo("새로운 칭호")
+        assertThat(saved.description).isEqualTo("새로운 칭호 설명")
+    }
+
+    @Test
+    fun `칭호를 삭제할 수 있다`() {
+        roleRepository.delete(savedRole)
+        entityManager.flush()
+
+        val found = roleRepository.findByName("테스트 칭호")
+        assertThat(found).isNull()
+    }
+
+    @Test
+    fun `모든 칭호를 조회할 수 있다`() {
+        entityManager.persist(
+            Role(
+                name = "추가 칭호 1",
+                description = "설명 1"
+            )
+        )
+        entityManager.persist(
+            Role(
+                name = "추가 칭호 2",
+                description = "설명 2"
+            )
+        )
+        entityManager.flush()
+
+        val roles = roleRepository.findAll()
+
+        assertThat(roles).hasSize(3)
+        assertThat(roles.map { it.name }).contains("테스트 칭호", "추가 칭호 1", "추가 칭호 2")
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/tool/MemberRoleReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/MemberRoleReaderTest.kt
@@ -1,0 +1,108 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.MemberRoleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class MemberRoleReaderTest {
+
+    @Mock
+    private lateinit var memberRoleRepository: MemberRoleRepository
+
+    @InjectMocks
+    private lateinit var memberRoleReader: MemberRoleReader
+
+    private lateinit var member: Member
+    private lateinit var role: Role
+
+    @BeforeEach
+    fun setUp() {
+        role = Role(id = 1L, name = "테스트 칭호", description = "설명")
+        member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role
+        )
+    }
+
+    @Test
+    fun `회원의 칭호 목록을 조회할 수 있다`() {
+        val memberRoles = listOf(
+            MemberRole(id = 1L, member = member, role = role),
+            MemberRole(id = 2L, member = member, role = Role(id = 2L, name = "다른 칭호", description = ""))
+        )
+        whenever(memberRoleRepository.findByMemberWithRole(member)).thenReturn(memberRoles)
+
+        val result = memberRoleReader.getMemberRolesByMember(member)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.role.name }).contains("테스트 칭호", "다른 칭호")
+    }
+
+    @Test
+    fun `회원의 칭호가 없으면 빈 리스트를 반환한다`() {
+        whenever(memberRoleRepository.findByMemberWithRole(member)).thenReturn(emptyList())
+
+        val result = memberRoleReader.getMemberRolesByMember(member)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `ID로 MemberRole을 조회할 수 있다`() {
+        val memberRole = MemberRole(id = 1L, member = member, role = role)
+        whenever(memberRoleRepository.findById(1L)).thenReturn(Optional.of(memberRole))
+
+        val result = memberRoleReader.getMemberRoleById(1L, member)
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.member.id).isEqualTo("test-id")
+        assertThat(result.role.name).isEqualTo("테스트 칭호")
+    }
+
+    @Test
+    fun `존재하지 않는 ID로 조회하면 예외가 발생한다`() {
+        whenever(memberRoleRepository.findById(999L)).thenReturn(Optional.empty())
+
+        val exception = assertThrows<RoleException> {
+            memberRoleReader.getMemberRoleById(999L, member)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.MEMBER_ROLE_NOT_FOUND)
+    }
+
+    @Test
+    fun `다른 회원의 MemberRole을 조회하면 예외가 발생한다`() {
+        val otherMember = Member.createEmailMember(
+            id = "other-id",
+            email = "other@example.com",
+            password = "password",
+            nickname = "다른사람",
+            defaultRole = role
+        )
+        val memberRole = MemberRole(id = 1L, member = otherMember, role = role)
+        whenever(memberRoleRepository.findById(1L)).thenReturn(Optional.of(memberRole))
+
+        val exception = assertThrows<RoleException> {
+            memberRoleReader.getMemberRoleById(1L, member)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.MEMBER_ROLE_UNAUTHORIZED)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/tool/MemberRoleReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/MemberRoleReaderTest.kt
@@ -37,7 +37,6 @@ class MemberRoleReaderTest {
             email = "test@example.com",
             password = "password",
             nickname = "테스터",
-            defaultRole = role
         )
     }
 
@@ -94,7 +93,6 @@ class MemberRoleReaderTest {
             email = "other@example.com",
             password = "password",
             nickname = "다른사람",
-            defaultRole = role
         )
         val memberRole = MemberRole(id = 1L, member = otherMember, role = role)
         whenever(memberRoleRepository.findById(1L)).thenReturn(Optional.of(memberRole))

--- a/src/test/kotlin/com/example/mykku/role/tool/MemberRoleWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/MemberRoleWriterTest.kt
@@ -1,0 +1,78 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.member.domain.Member
+import com.example.mykku.role.domain.MemberRole
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.MemberRoleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class MemberRoleWriterTest {
+
+    @Mock
+    private lateinit var memberRoleRepository: MemberRoleRepository
+
+    @InjectMocks
+    private lateinit var memberRoleWriter: MemberRoleWriter
+
+    private lateinit var member: Member
+    private lateinit var role: Role
+
+    @BeforeEach
+    fun setUp() {
+        role = Role(id = 1L, name = "테스트 칭호", description = "설명")
+        member = Member.createEmailMember(
+            id = "test-id",
+            email = "test@example.com",
+            password = "password",
+            nickname = "테스터",
+            defaultRole = role
+        )
+    }
+
+    @Test
+    fun `회원에게 칭호를 부여할 수 있다`() {
+        whenever(memberRoleRepository.existsByMemberAndRole(member, role)).thenReturn(false)
+        val savedMemberRole = MemberRole(id = 1L, member = member, role = role)
+        whenever(memberRoleRepository.save(any<MemberRole>())).thenReturn(savedMemberRole)
+
+        val result = memberRoleWriter.assignRole(member, role)
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.member.id).isEqualTo("test-id")
+        assertThat(result.role.name).isEqualTo("테스트 칭호")
+        verify(memberRoleRepository).save(any<MemberRole>())
+    }
+
+    @Test
+    fun `이미 보유한 칭호를 부여하면 예외가 발생한다`() {
+        whenever(memberRoleRepository.existsByMemberAndRole(member, role)).thenReturn(true)
+
+        val exception = assertThrows<RoleException> {
+            memberRoleWriter.assignRole(member, role)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.MEMBER_ROLE_ALREADY_EXISTS)
+    }
+
+    @Test
+    fun `MemberRole을 삭제할 수 있다`() {
+        val memberRole = MemberRole(id = 1L, member = member, role = role)
+
+        memberRoleWriter.delete(memberRole)
+
+        verify(memberRoleRepository).delete(memberRole)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/tool/MemberRoleWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/MemberRoleWriterTest.kt
@@ -38,7 +38,6 @@ class MemberRoleWriterTest {
             email = "test@example.com",
             password = "password",
             nickname = "테스터",
-            defaultRole = role
         )
     }
 

--- a/src/test/kotlin/com/example/mykku/role/tool/RoleReaderTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/RoleReaderTest.kt
@@ -1,0 +1,94 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.RoleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class RoleReaderTest {
+
+    @Mock
+    private lateinit var roleRepository: RoleRepository
+
+    @InjectMocks
+    private lateinit var roleReader: RoleReader
+
+    @Test
+    fun `ID로 칭호를 조회할 수 있다`() {
+        val role = Role(id = 1L, name = "테스트 칭호", description = "설명")
+        whenever(roleRepository.findById(1L)).thenReturn(Optional.of(role))
+
+        val result = roleReader.getRoleById(1L)
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.name).isEqualTo("테스트 칭호")
+    }
+
+    @Test
+    fun `존재하지 않는 ID로 조회하면 예외가 발생한다`() {
+        whenever(roleRepository.findById(999L)).thenReturn(Optional.empty())
+
+        val exception = assertThrows<RoleException> {
+            roleReader.getRoleById(999L)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_NOT_FOUND)
+    }
+
+    @Test
+    fun `이름으로 칭호를 조회할 수 있다`() {
+        val role = Role(id = 1L, name = "신입 덕후", description = "설명")
+        whenever(roleRepository.findByName("신입 덕후")).thenReturn(role)
+
+        val result = roleReader.getRoleByName("신입 덕후")
+
+        assertThat(result.name).isEqualTo("신입 덕후")
+    }
+
+    @Test
+    fun `존재하지 않는 이름으로 조회하면 예외가 발생한다`() {
+        whenever(roleRepository.findByName("존재하지않는칭호")).thenReturn(null)
+
+        val exception = assertThrows<RoleException> {
+            roleReader.getRoleByName("존재하지않는칭호")
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_NOT_FOUND)
+    }
+
+    @Test
+    fun `모든 칭호를 조회할 수 있다`() {
+        val roles = listOf(
+            Role(id = 1L, name = "칭호1", description = "설명1"),
+            Role(id = 2L, name = "칭호2", description = "설명2")
+        )
+        whenever(roleRepository.findAll()).thenReturn(roles)
+
+        val result = roleReader.getAllRoles()
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.name }).contains("칭호1", "칭호2")
+    }
+
+    @Test
+    fun `칭호 이름 존재 여부를 확인할 수 있다`() {
+        whenever(roleRepository.existsByName("신입 덕후")).thenReturn(true)
+        whenever(roleRepository.existsByName("존재하지않는칭호")).thenReturn(false)
+
+        val exists = roleReader.existsByName("신입 덕후")
+        val notExists = roleReader.existsByName("존재하지않는칭호")
+
+        assertThat(exists).isTrue()
+        assertThat(notExists).isFalse()
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/tool/RoleWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/RoleWriterTest.kt
@@ -1,0 +1,89 @@
+package com.example.mykku.role.tool
+
+import com.example.mykku.member.repository.MemberRepository
+import com.example.mykku.role.domain.Role
+import com.example.mykku.role.exception.RoleErrorCode
+import com.example.mykku.role.exception.RoleException
+import com.example.mykku.role.repository.RoleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class RoleWriterTest {
+
+    @Mock
+    private lateinit var roleRepository: RoleRepository
+
+    @Mock
+    private lateinit var memberRepository: MemberRepository
+
+    @InjectMocks
+    private lateinit var roleWriter: RoleWriter
+
+    @Test
+    fun `칭호를 저장할 수 있다`() {
+        val role = Role(id = null, name = "새 칭호", description = "설명")
+        val savedRole = Role(id = 1L, name = "새 칭호", description = "설명")
+        whenever(roleRepository.save(role)).thenReturn(savedRole)
+
+        val result = roleWriter.save(role)
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.name).isEqualTo("새 칭호")
+        verify(roleRepository).save(role)
+    }
+
+    @Test
+    fun `칭호를 생성할 수 있다`() {
+        val role = Role(id = 1L, name = "새 칭호", description = "설명")
+        whenever(roleRepository.save(any<Role>())).thenReturn(role)
+
+        val result = roleWriter.create("새 칭호", "설명")
+
+        assertThat(result.name).isEqualTo("새 칭호")
+        assertThat(result.description).isEqualTo("설명")
+        verify(roleRepository).save(any<Role>())
+    }
+
+    @Test
+    fun `칭호를 수정할 수 있다`() {
+        val role = Role(id = 1L, name = "기존 칭호", description = "기존 설명")
+
+        roleWriter.update(role, "수정된 칭호", "수정된 설명")
+
+        assertThat(role.name).isEqualTo("수정된 칭호")
+        assertThat(role.description).isEqualTo("수정된 설명")
+    }
+
+    @Test
+    fun `칭호를 삭제할 수 있다`() {
+        val role = Role(id = 1L, name = "삭제할 칭호", description = "설명")
+        whenever(memberRepository.existsByRole(role)).thenReturn(false)
+
+        roleWriter.delete(role)
+
+        verify(memberRepository).existsByRole(role)
+        verify(roleRepository).delete(role)
+    }
+
+    @Test
+    fun `회원이 사용 중인 칭호는 삭제할 수 없다`() {
+        val role = Role(id = 1L, name = "사용중인 칭호", description = "설명")
+        whenever(memberRepository.existsByRole(role)).thenReturn(true)
+
+        val exception = assertThrows<RoleException> {
+            roleWriter.delete(role)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_IN_USE)
+        verify(memberRepository).existsByRole(role)
+    }
+}

--- a/src/test/kotlin/com/example/mykku/role/tool/RoleWriterTest.kt
+++ b/src/test/kotlin/com/example/mykku/role/tool/RoleWriterTest.kt
@@ -1,9 +1,6 @@
 package com.example.mykku.role.tool
 
-import com.example.mykku.member.repository.MemberRepository
 import com.example.mykku.role.domain.Role
-import com.example.mykku.role.exception.RoleErrorCode
-import com.example.mykku.role.exception.RoleException
 import com.example.mykku.role.repository.RoleRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,9 +18,6 @@ class RoleWriterTest {
 
     @Mock
     private lateinit var roleRepository: RoleRepository
-
-    @Mock
-    private lateinit var memberRepository: MemberRepository
 
     @InjectMocks
     private lateinit var roleWriter: RoleWriter
@@ -56,34 +50,23 @@ class RoleWriterTest {
     @Test
     fun `칭호를 수정할 수 있다`() {
         val role = Role(id = 1L, name = "기존 칭호", description = "기존 설명")
+        val updatedRole = Role(id = 1L, name = "수정된 칭호", description = "수정된 설명")
+        whenever(roleRepository.existsByName("수정된 칭호")).thenReturn(false)
+        whenever(roleRepository.save(role)).thenReturn(updatedRole)
 
-        roleWriter.update(role, "수정된 칭호", "수정된 설명")
+        val result = roleWriter.update(role, "수정된 칭호", "수정된 설명")
 
-        assertThat(role.name).isEqualTo("수정된 칭호")
-        assertThat(role.description).isEqualTo("수정된 설명")
+        assertThat(result.name).isEqualTo("수정된 칭호")
+        assertThat(result.description).isEqualTo("수정된 설명")
+        verify(roleRepository).save(role)
     }
 
     @Test
     fun `칭호를 삭제할 수 있다`() {
         val role = Role(id = 1L, name = "삭제할 칭호", description = "설명")
-        whenever(memberRepository.existsByRole(role)).thenReturn(false)
 
         roleWriter.delete(role)
 
-        verify(memberRepository).existsByRole(role)
         verify(roleRepository).delete(role)
-    }
-
-    @Test
-    fun `회원이 사용 중인 칭호는 삭제할 수 없다`() {
-        val role = Role(id = 1L, name = "사용중인 칭호", description = "설명")
-        whenever(memberRepository.existsByRole(role)).thenReturn(true)
-
-        val exception = assertThrows<RoleException> {
-            roleWriter.delete(role)
-        }
-
-        assertThat(exception.errorCode).isEqualTo(RoleErrorCode.ROLE_IN_USE)
-        verify(memberRepository).existsByRole(role)
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #73 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 칭호 시스템 도입: 보유 칭호 조회 및 대표 칭호 변경 API 추가
  * 관리자 UI/API: 칭호 생성·수정·삭제 및 회원에게 칭호 부여 기능 추가

* **문서**
  * 칭호 API 및 관리자 칭호 API 문서화(REST Docs 포함)

* **데이터베이스**
  * 칭호 관련 테이블 및 관계 추가(롤·회원-칭호), 마이그레이션 적용

* **테스트/인프라**
  * 칭호 관련 단위·통합·REST Docs 테스트 추가 및 테스트 MySQL 설정·컨테이너 포트 업데이트

* **기타**
  * 회원 가입 시 기본 칭호 자동 부여 로직 제거 (명시적 부여로 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->